### PR TITLE
Implement packaging automation and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install cargo-bundle
+        if: matrix.os == 'macos-latest'
+        run: cargo install cargo-bundle
+      - name: Install NSIS
+        if: matrix.os == 'windows-latest'
+        run: choco install nsis -y
+      - name: Build
+        run: cargo build --workspace --release
+      - name: Package
+        run: cargo run --package packaging --bin packager
+

--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 [build-dependencies]
 cargo-bundle-licenses = "0.4"
+
+[[bin]]
+name = "packager"
+path = "src/main.rs"

--- a/packaging/installer.nsi
+++ b/packaging/installer.nsi
@@ -1,0 +1,9 @@
+; NSIS installer script for GooglePicz
+OutFile "GooglePiczSetup.exe"
+InstallDir "$PROGRAMFILES\GooglePicz"
+Section "Main"
+  SetOutPath "$INSTDIR"
+  File "..\target\release\googlepicz.exe"
+  CreateShortCut "$DESKTOP\GooglePicz.lnk" "$INSTDIR\googlepicz.exe"
+SectionEnd
+

--- a/packaging/src/main.rs
+++ b/packaging/src/main.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    packaging::package_all()?;
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- enable a new CI workflow to build and package on all platforms
- provide a simple NSIS installer script
- add an executable to the packaging crate
- implement macOS and Windows packaging logic

## Testing
- `cargo check --workspace`
- `cargo build --release` *(failed: terminated after long compilation)*

------
https://chatgpt.com/codex/tasks/task_e_6861686640bc8333bcc345e309c2ee05