### PR TITLE
Add Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,49 @@
+name: Rust CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Format check
+        run: cargo fmt -- --check
+
+      - name: Clippy check
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all
+
+      - name: Build release
+        run: cargo build --release --package googlepicz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: googlepicz
+          path: target/release/googlepicz*


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run formatting, linting, tests, and release build
- cache Cargo dependencies to speed up CI runs

## Testing
- `cargo fmt -- --check` *(fails: 'cargo-fmt' is not installed)*
- `cargo clippy -- -D warnings` *(fails: 'cargo-clippy' is not installed)*
- `cargo test --all`
- `cargo build --release --package googlepicz`


------
https://chatgpt.com/codex/tasks/task_e_686168677e2883339418f882b7f47ad9