### PR TITLE
Fix unused variable warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,10 @@ ui = { path = "ui" }
 cache = { path = "cache" }
 api_client = { path = "api_client" }
 packaging = { path = "packaging" }
+
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -13,10 +13,3 @@ ui = { workspace = true }
 
 [build-dependencies]
 cargo-bundle-licenses = "0.4"
-
-[profile.release]
-opt-level = "s"
-lto = true
-codegen-units = 1
-panic = "abort"
-strip = true

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -4,7 +4,7 @@ use oauth2::basic::BasicClient;
 use oauth2::reqwest::async_http_client;
 use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope, TokenResponse, TokenUrl};
 use keyring::Entry;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::net::TcpListener;
 use url::Url;
 
@@ -27,7 +27,7 @@ pub async fn authenticate() -> Result<(), Box<dyn std::error::Error>> {
     // PKCE code challenge
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
-    let (authorize_url, csrf_state) = client
+    let (authorize_url, _csrf_state) = client
         .authorize_url(CsrfToken::new_random)
         .add_scope(Scope::new("https://www.googleapis.com/auth/photoslibrary.readonly".to_string()))
         .set_pkce_challenge(pkce_challenge)

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -1,6 +1,6 @@
 //! Cache module for Google Photos data.
 
-use rusqlite::{Connection, Result as SqlResult, params};
+use rusqlite::{Connection, params};
 use std::path::Path;
 use std::error::Error;
 use std::fmt;
@@ -111,7 +111,7 @@ impl CacheManager {
         let media_item_iter = stmt.query_map([], |row| {
             let data: Vec<u8> = row.get(0)?;
             let item: api_client::MediaItem = serde_json::from_slice(&data)
-                .map_err(|e| rusqlite::Error::ExecuteReturnedResults)?; // A bit of a hack, but it works for now
+                .map_err(|_| rusqlite::Error::ExecuteReturnedResults)?; // A bit of a hack, but it works for now
             Ok(item)
         }).map_err(|e| CacheError::DatabaseError(format!("Failed to query all media items: {}", e)))?;
 

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -1,8 +1,8 @@
 //! Synchronization module for Google Photos data.
 
-use api_client::{ApiClient, ApiClientError};
-use auth::{get_access_token, refresh_access_token};
-use cache::{CacheManager, CacheError};
+use api_client::ApiClient;
+use auth::get_access_token;
+use cache::CacheManager;
 use std::path::Path;
 use std::error::Error;
 use std::fmt;

--- a/ui/src/image_loader.rs
+++ b/ui/src/image_loader.rs
@@ -11,7 +11,7 @@ use api_client;
 pub struct ImageLoader {
     cache_dir: PathBuf,
     client: reqwest::Client,
-    loaded_images: HashMap<String, Handle>,
+    _loaded_images: HashMap<String, Handle>,
 }
 
 impl ImageLoader {
@@ -20,7 +20,7 @@ impl ImageLoader {
         Self {
             cache_dir,
             client,
-            loaded_images: HashMap::new(),
+            _loaded_images: HashMap::new(),
         }
     }
 
@@ -55,10 +55,12 @@ impl ImageLoader {
         Ok(handle)
     }
 
-    pub fn get_cached_thumbnail(&self, media_id: &str) -> Option<Handle> {
+    #[allow(dead_code)]
+    pub fn get_cached_thumbnail(&self, _media_id: &str) -> Option<Handle> {
         None // Since we are not caching in memory anymore
     }
 
+    #[allow(dead_code)]
     pub async fn preload_thumbnails(&self, media_items: &[api_client::MediaItem]) {
         for item in media_items.iter().take(20) { // Preload first 20 thumbnails
             if let Err(e) = self.load_thumbnail(&item.id, &item.base_url).await {

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -8,7 +8,7 @@ use iced::{executor, Application, Command, Element, Length, Settings, Theme};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use cache::{CacheManager, CacheError};
+use cache::CacheManager;
 use api_client::MediaItem;
 use image_loader::ImageLoader;
 


### PR DESCRIPTION
## Summary
- remove unused imports and variables across the workspace
- silence dead code warnings in the image loader

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6861685f47d483338d81fd802f9e3e82