### PR TITLE
Add selected photo view and grid layout

### DIFF
--- a/ui/src/image_loader.rs
+++ b/ui/src/image_loader.rs
@@ -55,6 +55,26 @@ impl ImageLoader {
         Ok(handle)
     }
 
+    pub async fn load_full_image(&self, media_id: &str, base_url: &str) -> Result<Handle, Box<dyn std::error::Error>> {
+        let full_url = format!("{}=d", base_url);
+        let cache_path = self.cache_dir.join("full").join(format!("{}.jpg", media_id));
+
+        if cache_path.exists() {
+            return Ok(Handle::from_path(&cache_path));
+        }
+
+        let response = self.client.get(&full_url).send().await?;
+        let bytes = response.bytes().await?;
+
+        if let Some(parent) = cache_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+
+        fs::write(&cache_path, &bytes).await?;
+
+        Ok(Handle::from_path(&cache_path))
+    }
+
     pub fn get_cached_thumbnail(&self, media_id: &str) -> Option<Handle> {
         None // Since we are not caching in memory anymore
     }


### PR DESCRIPTION
## Summary
- add `load_full_image` to `ImageLoader`
- introduce `ViewState` with grid and viewer
- display photos in a grid and open full image on click
- fetch full-resolution images on demand
- show errors in a banner
- allow closing the viewer

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68619037d8008333b7655974ef914fb2