### PR TITLE
Add signing for CI installers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,10 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    env:
+      MAC_SIGN_ID: ${{ secrets.MAC_SIGN_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -101,6 +105,9 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    env:
+      WINDOWS_CERT: ${{ secrets.WINDOWS_CERT }}
+      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- sign the macOS .app and staple notarization ticket
- sign Windows installer when code signing cert and password are provided
- expose signing credentials in macOS and Windows CI jobs

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6861a255aadc8333ba5cd66a1bf501f9