### PR TITLE
Add album listing and filtering UI

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -60,6 +60,18 @@ struct SearchMediaItemsRequest {
     page_token: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateAlbumBody {
+    title: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateAlbumRequest {
+    album: CreateAlbumBody,
+}
+
 #[derive(Debug)]
 pub enum ApiClientError {
     RequestError(String),
@@ -168,6 +180,36 @@ impl ApiClient {
             .map_err(|e| ApiClientError::RequestError(e.to_string()))?;
 
         Ok((search_response.media_items.unwrap_or_default(), search_response.next_page_token))
+    }
+
+    pub async fn create_album(&self, title: &str) -> Result<Album, ApiClientError> {
+        let url = "https://photoslibrary.googleapis.com/v1/albums";
+
+        let request_body = CreateAlbumRequest {
+            album: CreateAlbumBody { title: title.to_string() },
+        };
+
+        let response = self.client.post(url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.access_token))
+            .header(CONTENT_TYPE, "application/json")
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| ApiClientError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(ApiClientError::GoogleApiError(error_text));
+        }
+
+        let album = response.json::<Album>().await
+            .map_err(|e| ApiClientError::RequestError(e.to_string()))?;
+
+        Ok(album)
+    }
+
+    pub async fn get_album_media_items(&self, album_id: &str, page_size: i32, page_token: Option<String>) -> Result<(Vec<MediaItem>, Option<String>), ApiClientError> {
+        self.search_media_items(Some(album_id.to_string()), page_size, page_token).await
     }
 }
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -13,3 +13,4 @@ api_client = { path = "../api_client" }
 reqwest = { version = "0.11", features = ["json"] }
 sync = { path = "../sync" }
 tracing = "0.1"
+auth = { path = "../auth" }


### PR DESCRIPTION
## Summary
- support creating albums and album-specific listing in API client
- track albums and selected album in UI state
- load albums on startup and refresh
- allow selecting an album to load its photos
- show album list in a sidebar

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6861a25135a48333820b022d364dfd25