### PR TITLE
Add config loading and settings UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ google-photos1 = "0.1"
 rusqlite = "0.34"
 rusqlite_migration = "2"
 dirs = "5.0"
+config = "0.13"
+serde = { version = "1.0", features = ["derive"] }
 
 auth = { path = "auth" }
 sync = { path = "sync" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -10,7 +10,9 @@ dirs = { workspace = true }
 auth = { workspace = true }
 sync = { workspace = true }
 ui = { workspace = true }
-config = "0.13"
+config = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+toml = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -13,3 +13,6 @@ api_client = { path = "../api_client" }
 reqwest = { version = "0.11", features = ["json"] }
 sync = { path = "../sync" }
 tracing = "0.1"
+config = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+toml = "0.7"


### PR DESCRIPTION
## Summary
- define workspace dependencies for `config` and `serde`
- implement configuration loader/saver in `app`
- read configuration in main application instead of environment variables
- expose config editing in the UI via new Settings screen

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861a2538454833385b98d0b0c1ad10b