### PR TITLE
Add file upload support

### DIFF
--- a/api_client/Cargo.toml
+++ b/api_client/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"
+wiremock = "0.6"
+tempfile = "3"
 

--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use std::error::Error;
 use std::fmt;
+use std::path::Path;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -60,6 +61,18 @@ struct SearchMediaItemsRequest {
     page_token: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BatchCreateResponse {
+    new_media_item_results: Vec<NewMediaItemResult>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NewMediaItemResult {
+    media_item: Option<MediaItem>,
+}
+
 #[derive(Debug)]
 pub enum ApiClientError {
     RequestError(String),
@@ -82,6 +95,7 @@ impl Error for ApiClientError {}
 pub struct ApiClient {
     client: reqwest::Client,
     access_token: String,
+    base_url: String,
 }
 
 impl ApiClient {
@@ -89,6 +103,16 @@ impl ApiClient {
         ApiClient {
             client: reqwest::Client::new(),
             access_token,
+            base_url: "https://photoslibrary.googleapis.com".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_base_url(access_token: String, base_url: String) -> Self {
+        ApiClient {
+            client: reqwest::Client::new(),
+            access_token,
+            base_url,
         }
     }
 
@@ -97,7 +121,7 @@ impl ApiClient {
     }
 
     pub async fn list_media_items(&self, page_size: i32, page_token: Option<String>) -> Result<(Vec<MediaItem>, Option<String>), ApiClientError> {
-        let mut url = format!("https://photoslibrary.googleapis.com/v1/mediaItems?pageSize={}", page_size);
+        let mut url = format!("{}/v1/mediaItems?pageSize={}", self.base_url, page_size);
         if let Some(token) = page_token {
             url.push_str(&format!("&pageToken={}", token));
         }
@@ -120,7 +144,7 @@ impl ApiClient {
     }
 
     pub async fn list_albums(&self, page_size: i32, page_token: Option<String>) -> Result<(Vec<Album>, Option<String>), ApiClientError> {
-        let mut url = format!("https://photoslibrary.googleapis.com/v1/albums?pageSize={}", page_size);
+        let mut url = format!("{}/v1/albums?pageSize={}", self.base_url, page_size);
         if let Some(token) = page_token {
             url.push_str(&format!("&pageToken={}", token));
         }
@@ -143,7 +167,7 @@ impl ApiClient {
     }
 
     pub async fn search_media_items(&self, album_id: Option<String>, page_size: i32, page_token: Option<String>) -> Result<(Vec<MediaItem>, Option<String>), ApiClientError> {
-        let url = "https://photoslibrary.googleapis.com/v1/mediaItems:search";
+        let url = format!("{}/v1/mediaItems:search", self.base_url);
         
         let request_body = SearchMediaItemsRequest {
             album_id,
@@ -169,11 +193,108 @@ impl ApiClient {
 
         Ok((search_response.media_items.unwrap_or_default(), search_response.next_page_token))
     }
+
+    pub async fn upload_media_item(&self, path: &Path, album_id: Option<String>) -> Result<MediaItem, ApiClientError> {
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| ApiClientError::Other("Invalid file path".to_string()))?
+            .to_string_lossy();
+        let bytes = tokio::fs::read(path)
+            .await
+            .map_err(|e| ApiClientError::Other(e.to_string()))?;
+
+        let upload_url = format!("{}/v1/uploads", self.base_url);
+        let response = self
+            .client
+            .post(&upload_url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.access_token))
+            .header("X-Goog-Upload-File-Name", file_name.as_ref())
+            .header("X-Goog-Upload-Protocol", "raw")
+            .body(bytes)
+            .send()
+            .await
+            .map_err(|e| ApiClientError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(ApiClientError::GoogleApiError(text));
+        }
+
+        let upload_token = response.text().await.map_err(|e| ApiClientError::RequestError(e.to_string()))?;
+        self.add_media_item(&upload_token, file_name.as_ref(), album_id).await
+    }
+
+    pub async fn add_media_item(&self, upload_token: &str, file_name: &str, album_id: Option<String>) -> Result<MediaItem, ApiClientError> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct SimpleMediaItem<'a> {
+            upload_token: &'a str,
+            file_name: &'a str,
+        }
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct NewMediaItem<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            description: Option<String>,
+            simple_media_item: SimpleMediaItem<'a>,
+        }
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct BatchCreateRequest<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            album_id: Option<String>,
+            new_media_items: Vec<NewMediaItem<'a>>,
+        }
+
+        let request_body = BatchCreateRequest {
+            album_id,
+            new_media_items: vec![NewMediaItem {
+                description: None,
+                simple_media_item: SimpleMediaItem {
+                    upload_token,
+                    file_name,
+                },
+            }],
+        };
+
+        let url = format!("{}/v1/mediaItems:batchCreate", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.access_token))
+            .header(CONTENT_TYPE, "application/json")
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(|e| ApiClientError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(ApiClientError::GoogleApiError(text));
+        }
+
+        let parsed = response
+            .json::<BatchCreateResponse>()
+            .await
+            .map_err(|e| ApiClientError::RequestError(e.to_string()))?;
+        let result = parsed
+            .new_media_item_results
+            .into_iter()
+            .next()
+            .ok_or_else(|| ApiClientError::Other("No result".to_string()))?;
+        result.media_item.ok_or_else(|| ApiClientError::Other("No media item returned".to_string()))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use wiremock::{MockServer, Mock, ResponseTemplate};
+    use wiremock::matchers::{method, path, header};
+    use tempfile;
 
     #[test]
     fn test_parse_list_albums_response() {
@@ -198,5 +319,46 @@ mod tests {
         assert_eq!(albums[0].id, "1");
         assert_eq!(albums[0].title.as_deref(), Some("Test Album"));
         assert_eq!(parsed.next_page_token, Some("token123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_upload_media_item_request_format() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/uploads"))
+            .and(header("X-Goog-Upload-Protocol", "raw"))
+            .and(header("X-Goog-Upload-File-Name", "test.jpg"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("TOKEN"))
+            .mount(&server)
+            .await;
+
+        let sample_response = serde_json::json!({
+            "newMediaItemResults": [{
+                "mediaItem": {
+                    "id": "1",
+                    "description": null,
+                    "productUrl": "http://example.com/1",
+                    "baseUrl": "http://example.com/base",
+                    "mimeType": "image/jpeg",
+                    "mediaMetadata": {"creationTime": "t", "width": "1", "height": "1"},
+                    "filename": "test.jpg"
+                }
+            }]
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/mediaItems:batchCreate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_response))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.jpg");
+        std::fs::write(&file_path, "hello world").unwrap();
+
+        let client = ApiClient::with_base_url("token".into(), server.uri());
+        let item = client.upload_media_item(&file_path, None).await.unwrap();
+        assert_eq!(item.filename, "test.jpg");
     }
 }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -13,3 +13,5 @@ api_client = { path = "../api_client" }
 reqwest = { version = "0.11", features = ["json"] }
 sync = { path = "../sync" }
 tracing = "0.1"
+auth = { path = "../auth" }
+rfd = { version = "0.15", default-features = false, features = ["tokio", "xdg-portal"] }


### PR DESCRIPTION
## Summary
- add configurable base URL and implement media item uploads in API client
- support selecting local files and uploading via UI
- mock upload flow in new unit test

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6861a252bb6c83339f346c041a68b729