### PR TITLE
Add album browsing

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -12,4 +12,5 @@ cache = { path = "../cache" }
 api_client = { path = "../api_client" }
 reqwest = { version = "0.11", features = ["json"] }
 sync = { path = "../sync" }
+auth = { path = "../auth" }
 tracing = { workspace = true }


### PR DESCRIPTION
## Summary
- add structs and methods to ApiClient for creating and listing album media items
- track albums and selected album in the UI
- load albums on startup and refresh
- filter displayed photos by album and show album buttons
- include auth dependency in UI

## Testing
- `cargo check -q`
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a4fe90a48333bd94800a47f496e6