### PR TITLE
Add dismissible error banner in UI

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -219,7 +219,9 @@ impl ApiClient {
 
     /// Retrieve media items for a specific album using its ID.
     pub async fn get_album_media_items(&self, album_id: &str, page_size: i32, page_token: Option<String>) -> Result<(Vec<MediaItem>, Option<String>), ApiClientError> {
-        self.search_media_items(Some(album_id.to_string()), page_size, page_token).await
+        self
+            .search_media_items(Some(album_id.to_string()), page_size, page_token, None)
+            .await
     }
 }
 


### PR DESCRIPTION
## Summary
- fix missing argument for `get_album_media_items`
- add error dismissal message and UI banner

## Testing
- `cargo check -p ui`


------
https://chatgpt.com/codex/tasks/task_e_6861b407e29483339a070cc839f10b9c