### PR TITLE
Add configurable runtime settings

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -219,7 +219,9 @@ impl ApiClient {
 
     /// Retrieve media items for a specific album using its ID.
     pub async fn get_album_media_items(&self, album_id: &str, page_size: i32, page_token: Option<String>) -> Result<(Vec<MediaItem>, Option<String>), ApiClientError> {
-        self.search_media_items(Some(album_id.to_string()), page_size, page_token).await
+        self
+            .search_media_items(Some(album_id.to_string()), page_size, page_token, None)
+            .await
     }
 }
 

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 
 pub struct AppConfig {
     pub log_level: String,
+    pub oauth_redirect_port: u16,
+    pub thumbnails_preload: usize,
+    pub sync_interval_minutes: u64,
 }
 
 impl AppConfig {
@@ -12,9 +15,25 @@ impl AppConfig {
             builder = builder.add_source(config::File::from(path).required(false));
         }
         let cfg = builder.build().unwrap_or_default();
+
         let log_level = cfg
             .get_string("log_level")
             .unwrap_or_else(|_| "info".to_string());
-        Self { log_level }
+        let oauth_redirect_port = cfg
+            .get_int("oauth_redirect_port")
+            .unwrap_or(8080) as u16;
+        let thumbnails_preload = cfg
+            .get_int("thumbnails_preload")
+            .unwrap_or(20) as usize;
+        let sync_interval_minutes = cfg
+            .get_int("sync_interval_minutes")
+            .unwrap_or(5) as u64;
+
+        Self {
+            log_level,
+            oauth_redirect_port,
+            thumbnails_preload,
+            sync_interval_minutes,
+        }
     }
 }

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -160,7 +160,7 @@ mod tests {
         // Attempt to authenticate if no token is found
         if get_access_token().is_err() {
             tracing::error!("No access token found. Attempting to authenticate...");
-            authenticate().await.expect("Failed to authenticate for sync test");
+            authenticate(8080).await.expect("Failed to authenticate for sync test");
         }
 
         let temp_file = NamedTempFile::new().expect("Failed to create temp file");

--- a/ui/src/image_loader.rs
+++ b/ui/src/image_loader.rs
@@ -79,8 +79,8 @@ impl ImageLoader {
         None // Since we are not caching in memory anymore
     }
 
-    pub async fn preload_thumbnails(&self, media_items: &[api_client::MediaItem]) {
-        for item in media_items.iter().take(20) { // Preload first 20 thumbnails
+    pub async fn preload_thumbnails(&self, media_items: &[api_client::MediaItem], count: usize) {
+        for item in media_items.iter().take(count) {
             if let Err(e) = self.load_thumbnail(&item.id, &item.base_url).await {
                 tracing::error!("Failed to preload thumbnail for {}: {}", &item.id, e);
             }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -17,8 +17,8 @@ use tokio::sync::mpsc;
 use sync::SyncProgress;
 use chrono::{DateTime, Utc};
 
-pub fn run(progress: Option<mpsc::UnboundedReceiver<SyncProgress>>) -> iced::Result {
-    GooglePiczUI::run(Settings::with_flags(progress))
+pub fn run(progress: Option<mpsc::UnboundedReceiver<SyncProgress>>, preload: usize) -> iced::Result {
+    GooglePiczUI::run(Settings::with_flags((progress, preload)))
 }
 
 #[derive(Debug, Clone)]
@@ -59,15 +59,17 @@ pub struct GooglePiczUI {
     state: ViewState,
     selected_album: Option<String>,
     errors: Vec<String>,
+    preload_count: usize,
 }
 
 impl Application for GooglePiczUI {
     type Executor = executor::Default;
     type Message = Message;
     type Theme = Theme;
-    type Flags = Option<mpsc::UnboundedReceiver<SyncProgress>>;
+    type Flags = (Option<mpsc::UnboundedReceiver<SyncProgress>>, usize);
 
     fn new(flags: Self::Flags) -> (Self, Command<Message>) {
+        let (progress_flag, preload_count) = flags;
         let cache_path = dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join(".googlepicz")
@@ -91,7 +93,7 @@ impl Application for GooglePiczUI {
 
         let image_loader = Arc::new(Mutex::new(ImageLoader::new(thumbnail_cache_path)));
 
-        let progress_receiver = flags.map(|rx| Arc::new(Mutex::new(rx)));
+        let progress_receiver = progress_flag.map(|rx| Arc::new(Mutex::new(rx)));
 
         let app = Self {
             photos: Vec::new(),
@@ -108,6 +110,7 @@ impl Application for GooglePiczUI {
             state: ViewState::Grid,
             selected_album: None,
             errors: Vec::new(),
+            preload_count,
         };
 
         (
@@ -153,9 +156,9 @@ impl Application for GooglePiczUI {
                 match result {
                     Ok(photos) => {
                         self.photos = photos;
-                        // Start loading thumbnails for all photos
+                        // Start loading thumbnails for configured number of photos
                         let mut commands = Vec::new();
-                        for photo in &self.photos {
+                        for photo in self.photos.iter().take(self.preload_count) {
                             let media_id = photo.id.clone();
                             let base_url = photo.base_url.clone();
                             commands.push(Command::perform(async {}, move |_| Message::LoadThumbnail(media_id.clone(), base_url.clone())));


### PR DESCRIPTION
## Summary
- extend configuration loader with OAuth port, thumbnail preload count and sync interval
- pass config to main logic and authentication
- limit thumbnail loading using configuration
- update tests and API client

## Testing
- `cargo check --all`
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_6861b4091cf8833382cea9b366a0cf6a