### PR TITLE
Add album caching and metadata normalization

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -219,7 +219,7 @@ impl ApiClient {
 
     /// Retrieve media items for a specific album using its ID.
     pub async fn get_album_media_items(&self, album_id: &str, page_size: i32, page_token: Option<String>) -> Result<(Vec<MediaItem>, Option<String>), ApiClientError> {
-        self.search_media_items(Some(album_id.to_string()), page_size, page_token).await
+        self.search_media_items(Some(album_id.to_string()), page_size, page_token, None).await
     }
 }
 


### PR DESCRIPTION
## Summary
- extend DB migrations for album support
- normalize `media_items` metadata to integers
- add album/date query methods
- update API client album fetch call
- test migrations from old databases and new queries

## Testing
- `cargo test -p cache -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6861b4112e848333951f5e6c5b75e6af