### PR TITLE
Enable and mock previously ignored tests

### DIFF
--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -10,3 +10,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 url = "2.2"
 webbrowser = "0.8"
 tracing = { workspace = true }
+
+[dev-dependencies]
+serial_test = "2"

--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
+[dev-dependencies]
+tempfile = "3"
 [build-dependencies]
 cargo-bundle-licenses = "0.4"
 

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = "1.0"
 
 [dev-dependencies]
 tempfile = "3"
+httpmock = "0.6"


### PR DESCRIPTION
## Summary
- enable disabled auth tests by mocking the keyring and OAuth calls
- allow overriding Google Photos API base URL for tests
- add HTTP and keyring mocks for sync
- simulate cargo commands in packaging tests
- add needed dev-dependencies

## Testing
- `cargo test -p auth`
- `cargo test -p sync`
- `cargo test -p packaging`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6861b406912c83338a6dc4b0a0431b4c