### PR TITLE
Fix unused imports and variables

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -5,7 +5,7 @@ use oauth2::reqwest::async_http_client;
 use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope, TokenResponse, TokenUrl};
 use keyring::Entry;
 use std::time::{SystemTime, Duration, UNIX_EPOCH};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::net::TcpListener;
 use url::Url;
 
@@ -31,7 +31,7 @@ pub async fn authenticate(redirect_port: u16) -> Result<(), Box<dyn std::error::
     // PKCE code challenge
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
-    let (authorize_url, csrf_state) = client
+    let (authorize_url, _csrf_state) = client
         .authorize_url(CsrfToken::new_random)
         .add_scope(Scope::new("https://www.googleapis.com/auth/photoslibrary.readonly".to_string()))
         .set_pkce_challenge(pkce_challenge)

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -2,7 +2,7 @@
 
 use api_client::ApiClient;
 use auth::ensure_access_token_valid;
-use cache::{CacheError, CacheManager};
+use cache::CacheManager;
 use std::path::Path;
 use std::error::Error;
 use std::fmt;

--- a/ui/src/image_loader.rs
+++ b/ui/src/image_loader.rs
@@ -1,6 +1,5 @@
 //! Image loading and caching functionality for GooglePicz UI.
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::fs;
 use reqwest;
@@ -11,7 +10,6 @@ use api_client;
 pub struct ImageLoader {
     cache_dir: PathBuf,
     client: reqwest::Client,
-    loaded_images: HashMap<String, Handle>,
 }
 
 impl ImageLoader {
@@ -20,7 +18,6 @@ impl ImageLoader {
         Self {
             cache_dir,
             client,
-            loaded_images: HashMap::new(),
         }
     }
 
@@ -75,10 +72,12 @@ impl ImageLoader {
         Ok(Handle::from_path(&cache_path))
     }
 
-    pub fn get_cached_thumbnail(&self, media_id: &str) -> Option<Handle> {
+    #[allow(dead_code)]
+    pub fn get_cached_thumbnail(&self, _media_id: &str) -> Option<Handle> {
         None // Since we are not caching in memory anymore
     }
 
+    #[allow(dead_code)]
     pub async fn preload_thumbnails(&self, media_items: &[api_client::MediaItem], count: usize) {
         for item in media_items.iter().take(count) {
             if let Err(e) = self.load_thumbnail(&item.id, &item.base_url).await {


### PR DESCRIPTION
## Summary
- clean up unused imports in `auth` and `sync`
- drop unused field and variable in `ImageLoader`
- silence warnings in optional ImageLoader helpers

## Testing
- `cargo check`
- `cargo clippy -- -D warnings` *(fails: 'cargo-clippy' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861be4f46648333b16a6a7e78a2ff21