### PR TITLE
Update TODO and add config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ GooglePicz/
 ## 📝 Documentation
 
 See [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md) for detailed technical documentation.
+See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for user configuration options.
 
 ## Packaging & Signing
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,12 @@
+# Configuration Guide
+
+`AppConfig` controls runtime behavior of GooglePicz. Values can be loaded from `~/.googlepicz/config` using the [config](https://docs.rs/config) crate.
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `log_level` | `String` | `"info"` | Verbosity of application logging. Valid values follow the `env_logger` log levels. |
+| `oauth_redirect_port` | `u16` | `8080` | Port used during OAuth authentication for the local redirect server. |
+| `thumbnails_preload` | `usize` | `20` | Number of thumbnails to prefetch when loading an album. |
+| `sync_interval_minutes` | `u64` | `5` | Time between automatic background sync operations. |
+
+Edit or create `~/.googlepicz/config` and provide any of these keys to customize the application.

--- a/docs/TODO123.md
+++ b/docs/TODO123.md
@@ -3,16 +3,15 @@
 ## High Priority Tasks
 - **Verify Build:** Run `cargo check --all` and `cargo build` to ensure the project compiles successfully after the configuration and path fixes.
 - **Implement UI Logic:** The UI currently displays photo metadata but needs implementation for actual user interactions (e.g., selecting a photo, viewing full-resolution images, managing albums).
-- **Refine Error Handling:** While error enums exist, the UI should display user-friendly error messages instead of printing to `stderr`. Implement a global error state or notification system in the UI.
+- **Add Album Management:** Provide features to create, rename, and delete albums within the app.
 
 ## Medium Priority Tasks
 - **Optimize Caching:** The cache now uses a normalized schema with separate `media_items`, `media_metadata`, `albums`, and `album_media_items` tables for efficient SQL queries.
-- **Implement Full Packaging:** The `packaging` module is currently a placeholder. Implement proper bundling for macOS (`.app`) and Windows (`.msi`/`.exe`) using `cargo-bundle` or other platform-specific tools.
 - **Background Sync Robustness:** The background sync in `main.rs` is started in a `tokio::spawn` task. Add more robust error handling and potentially a mechanism to communicate sync status back to the UI (e.g., via channels).
+- **Add CLI Sync Command:** Allow manual triggering of the sync process via a command-line option.
+- **Performance Tuning:** Profile startup time and optimize for large photo libraries.
 
 ## Low Priority Tasks
-- **Configuration Management:** Move hardcoded values (like the number of thumbnails to preload) into a configuration file or UI setting.
-- **Improve Test Coverage:** Enable and expand the ignored tests. Mock the Google Photos API and `keyring` service to allow for fully automated testing without requiring manual intervention or real credentials.
 - **Code Refinements:**
   - In `ui/src/lib.rs`, the creation of the `cache_manager` can be simplified.
   - Review all `.unwrap()` and `.expect()` calls to ensure they are appropriate and won't cause panics in edge cases.


### PR DESCRIPTION
## Summary
- prune completed items from `TODO123.md`
- add new feature ideas and performance tuning
- document configuration options in new `CONFIGURATION.md`
- link configuration guide from README

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68620d52500883338b8ece3b60cf31aa