### PR TITLE
Enhance Linux package versioning

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -112,6 +112,15 @@ The application and packaging scripts rely on several environment variables:
 - `LINUX_SIGN_KEY` – GPG key ID used to sign the generated `.deb` package (optional).
 - `MOCK_REFRESH_TOKEN` – Used only for automated tests to bypass live authentication.
 
+### Packaging
+Run the packager to create platform installers:
+
+```bash
+cargo run --package packaging --bin packager
+```
+
+On Linux the version number is read from `workspace.package.version` in `Cargo.toml` and passed to `cargo deb` via `--deb-version`. The generated file `target/debian/GooglePicz-<version>.deb` will contain the version in its name.
+
 ## 📝 Next Steps
 
 ### Short-term Goals

--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
+toml = "0.8"
 
 [dev-dependencies]
 serial_test = "2"
+cargo-deb = "1"
 [build-dependencies]
 cargo-bundle-licenses = "0.4"
 


### PR DESCRIPTION
## Summary
- read workspace version from Cargo.toml when packaging
- pass `--deb-version` to cargo-deb and rename the file to `GooglePicz-<ver>.deb`
- record dependency on `cargo-deb` and use `toml` to parse the manifest
- document new packaging steps

## Testing
- `cargo test --quiet`
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68623dbae4688333b27fe09d6cbf1521