### PR TITLE
Add sync_cli binary for command line syncing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
 
 auth = { path = "auth" }
 sync = { path = "sync" }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ GooglePicz/
 See [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md) for detailed technical documentation.
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for user configuration options.
 
+## Sync CLI
+
+Run the `sync_cli` binary for manual synchronization or to inspect the local cache.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- sync
+```
+
+Synchronizes all media items and prints progress.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- status
+```
+
+Displays the timestamp of the last sync along with the number of cached photos.
+
 ## Packaging & Signing
 
 The `packager` binary produces installers for macOS, Windows and Debian-based Linux systems.

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -10,10 +10,12 @@ dirs = { workspace = true }
 auth = { workspace = true }
 sync = { workspace = true }
 ui = { workspace = true }
+cache = { workspace = true }
 config = "0.13"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
+clap = { workspace = true }
 
 [build-dependencies]
 cargo-bundle-licenses = "0.4"

--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -1,0 +1,60 @@
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+use dirs;
+use tokio::sync::mpsc;
+use sync::{Syncer, SyncProgress};
+use cache::CacheManager;
+
+#[derive(Parser)]
+#[command(name = "sync_cli", about = "GooglePicz synchronization CLI")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Perform a full synchronization
+    Sync,
+    /// Show last sync time and cached item count
+    Status,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    let cache_dir = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".googlepicz");
+    let db_path = cache_dir.join("cache.sqlite");
+
+    match cli.command {
+        Commands::Sync => {
+            let mut syncer = Syncer::new(&db_path).await?;
+            let (tx, mut rx) = mpsc::unbounded_channel();
+            tokio::spawn(async move {
+                while let Some(p) = rx.recv().await {
+                    match p {
+                        SyncProgress::ItemSynced(n) => println!("Synced {} items...", n),
+                        SyncProgress::Finished(total) => println!("Finished sync: {} items", total),
+                    }
+                }
+            });
+            syncer.sync_media_items(Some(tx)).await?;
+        }
+        Commands::Status => {
+            if !db_path.exists() {
+                println!("No cache found at {:?}", db_path);
+                return Ok(());
+            }
+            let cache = CacheManager::new(&db_path)?;
+            let last = cache.get_last_sync()?;
+            let count = cache.get_all_media_items()?.len();
+            println!("Last sync: {}", last.to_rfc3339());
+            println!("Cached items: {}", count);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add clap to workspace
- create a new `sync_cli` binary under `app/src/bin`
- implement `sync` and `status` commands using `Syncer`
- document CLI usage in README

## Testing
- `cargo test --all --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68623dba549c8333bdadcc358af2bb72