### PR TITLE
Implement album dialog and listing

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -390,7 +390,7 @@ impl Application for GooglePiczUI {
         let header = row![
             text("GooglePicz").size(24),
             button("Refresh").on_press(Message::RefreshPhotos),
-            button("New Album...").on_press(Message::ShowCreateAlbumDialog),
+            button("New Album…").on_press(Message::ShowCreateAlbumDialog),
             text(if self.syncing {
                 format!("Syncing {} items...", self.synced)
             } else {


### PR DESCRIPTION
## Summary
- add ellipsis in "New Album" UI label
- expose `CacheManager::get_all_albums`
- test album retrieval from cache

## Testing
- `cargo test -p api_client --quiet`
- `cargo test -p cache --quiet`
- `cargo test -p sync --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6862435f25908333b011cc1e239a79a4