### PR TITLE
Versioned Linux packaging

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -112,6 +112,17 @@ The application and packaging scripts rely on several environment variables:
 - `LINUX_SIGN_KEY` – GPG key ID used to sign the generated `.deb` package (optional).
 - `MOCK_REFRESH_TOKEN` – Used only for automated tests to bypass live authentication.
 
+### Packaging installers
+Run the packager binary to create platform specific artifacts. The version is
+read from `Cargo.toml`, so each file is versioned automatically.
+
+```bash
+cargo run --package packaging --bin packager
+```
+
+Generated files include `GooglePicz-<version>-Setup.exe` for Windows and
+`GooglePicz-<version>.deb` for Debian-based Linux.
+
 ## 🐳 CI Docker Image
 
 The repository includes a `Dockerfile.ci` used to build a container image with

--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
+toml = "0.5"
 
 [dev-dependencies]
 serial_test = "2"
+cargo-deb = "3.1"
 [build-dependencies]
 cargo-bundle-licenses = "0.4"
 


### PR DESCRIPTION
## Summary
- add `toml` and `cargo-deb` crates to packaging
- read workspace version from `Cargo.toml`
- create Debian package with `--deb-version` and rename output to include version
- document how to run the packager

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_68624a8cd434833398f9136b329e4394