### PR TITLE
Document sync CLI utility

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -123,6 +123,24 @@ cargo run --package packaging --bin packager
 Generated files include `GooglePicz-<version>-Setup.exe` for Windows and
 `GooglePicz-<version>.deb` for Debian-based Linux.
 
+## Sync CLI
+
+In addition to the main application UI, the project provides a command line
+utility for manual synchronization and cache inspection. The binary lives under
+`app/src/bin/sync_cli.rs` and is built alongside the rest of the workspace.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- sync
+```
+
+Synchronizes all media items and prints progress to stdout.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- status
+```
+
+Displays the last sync timestamp and the number of cached photos.
+
 ## 🐳 CI Docker Image
 
 The repository includes a `Dockerfile.ci` used to build a container image with


### PR DESCRIPTION
## Summary
- add a section to the developer docs describing the `sync_cli` binary

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68624a8c5e508333a5447d5be72387b8