### PR TITLE
Add sync_cli usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ cargo run --package googlepicz --bin sync_cli -- sync
 Synchronizes all media items and prints progress.
 
 ```bash
+cargo run --package googlepicz --bin sync_cli -- --help
+```
+
+Displays the available commands.
+
+```bash
 cargo run --package googlepicz --bin sync_cli -- status
 ```
 


### PR DESCRIPTION
## Summary
- document `sync_cli --help` usage

## Testing
- `cargo check`
- ❌ `rustup component add rustfmt` *(failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68627820bb6c8333a9478060c040e06d