### PR TITLE
Add sync_cli binary and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ See the following documents for additional details:
 ## Sync CLI
 
 Run the `sync_cli` binary for manual synchronization or to inspect the local cache.
+The tool exposes subcommands for `sync` and `status` and prints progress updates
+to stdout while downloading items.
 
 ```bash
 cargo run --package googlepicz --bin sync_cli -- sync

--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -1,12 +1,12 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
-use dirs;
+use dirs::home_dir;
 use tokio::sync::mpsc;
 use sync::{Syncer, SyncProgress};
 use cache::CacheManager;
 
 #[derive(Parser)]
-#[command(name = "sync_cli", about = "GooglePicz synchronization CLI")]
+#[command(name = "sync_cli", author, version, about = "GooglePicz synchronization CLI")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -24,7 +24,7 @@ enum Commands {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    let cache_dir = dirs::home_dir()
+    let cache_dir = home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".googlepicz");
     let db_path = cache_dir.join("cache.sqlite");


### PR DESCRIPTION
## Summary
- add CLI attributes for version and author
- clarify sync_cli docs about progress messages
- small refactor of sync_cli code

## Testing
- `cargo check --quiet`
- `cargo run --package googlepicz --bin sync_cli -- --help`
- `cargo run --package googlepicz --bin sync_cli -- status`

------
https://chatgpt.com/codex/tasks/task_e_686286f3e8d483338bd3802e92237dba