### PR TITLE
Improve linux packaging script

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -115,8 +115,9 @@ The application and packaging scripts rely on several environment variables:
 ### Packaging installers
 Run the packager binary to create platform specific artifacts. The version is
 read from `Cargo.toml`, so each file is versioned automatically. Linux packages
-are built using `cargo deb` with the `--deb-version` flag, which requires the
-`cargo-deb` crate in `dev-dependencies`.
+are built using `cargo deb` with the `--deb-version` flag, requiring the
+`cargo-deb` crate in `dev-dependencies`. The `.deb` output is renamed to include
+the version just like the Windows installer.
 
 ```bash
 cargo run --package packaging --bin packager

--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -10,6 +10,7 @@ toml = "0.5"
 
 [dev-dependencies]
 serial_test = "2"
+# Required for building Debian packages
 cargo-deb = "3.1"
 [build-dependencies]
 cargo-bundle-licenses = "0.4"

--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -170,7 +170,8 @@ fn create_linux_package() -> Result<(), PackagingError> {
     run_command("cargo", &["deb", "--deb-version", &version])?;
 
     // Locate the produced .deb file in target/debian
-    let deb_dir = get_project_root().join("target/debian");
+    let root = get_project_root();
+    let deb_dir = root.join("target/debian");
     let deb_entries = match fs::read_dir(&deb_dir) {
         Ok(entries) => entries,
         Err(_) => {
@@ -203,7 +204,7 @@ fn create_linux_package() -> Result<(), PackagingError> {
     }
 
     // Rename to include the version similar to the Windows installer
-    let versioned = get_project_root().join(format!("GooglePicz-{}.deb", version));
+    let versioned = root.join(format!("GooglePicz-{}.deb", version));
     fs::rename(&deb_path, &versioned)
         .map_err(|e| PackagingError::Other(format!("Failed to rename .deb: {}", e)))?;
 


### PR DESCRIPTION
## Summary
- clean up linux installer code to reuse project root
- document deb packaging behavior
- clarify dev dependency on `cargo-deb`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6862a50d25e88333aa87903a7be518f8