### PR TITLE
Add CI Docker image and update workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,13 +14,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM rust:1-slim-bullseye
+FROM rust:slim-bullseye
 
 # Install common build dependencies
 RUN apt-get update && \

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -148,11 +148,14 @@ Displays the last sync timestamp and the number of cached photos.
 ## 🐳 CI Docker Image
 
 The repository includes a `Dockerfile.ci` used to build a container image with
-Rust and the packaging tools required for CI. To build and publish the image:
+stable Rust and the packaging tools required for CI. To build and publish the image:
 
 ```bash
 # Build the image
 docker build -f Dockerfile.ci -t ghcr.io/christopher-schulze/googlepicz-ci:latest .
+
+# Authenticate to GHCR (if not already logged in)
+echo "$CR_PAT" | docker login ghcr.io -u USERNAME --password-stdin
 
 # Push to GitHub Container Registry
 docker push ghcr.io/christopher-schulze/googlepicz-ci:latest


### PR DESCRIPTION
## Summary
- base CI image on latest stable Rust
- rely on prebuilt image in GitHub Actions
- mention image authentication in docs

## Testing
- `cargo test --workspace`
- `yamllint .github/workflows/rust.yml`

------
https://chatgpt.com/codex/tasks/task_e_6863a2c518708333a3bec573efdee129