### PR TITLE
Read app version for NSIS installer from workspace package

### DIFF
--- a/packaging/installer.nsi
+++ b/packaging/installer.nsi
@@ -2,14 +2,16 @@
 !include "MUI2.nsh"
 
 !define APP_NAME "GooglePicz"
+
+; These version components must be provided by the packager via /D options
 !ifndef APP_VERSION_MAJOR
-!define APP_VERSION_MAJOR "0"
+!error "APP_VERSION_MAJOR not defined"
 !endif
 !ifndef APP_VERSION_MINOR
-!define APP_VERSION_MINOR "1"
+!error "APP_VERSION_MINOR not defined"
 !endif
 !ifndef APP_VERSION_PATCH
-!define APP_VERSION_PATCH "0"
+!error "APP_VERSION_PATCH not defined"
 !endif
 !define APP_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}"
 


### PR DESCRIPTION
## Summary
- read workspace package version when creating the Windows installer
- expect version defines from packager in `installer.nsi`

## Testing
- `cargo test -p packaging -- --test-threads=1`
- `cargo test --no-run`

`cargo fmt` failed: rustfmt component could not be installed (blocked network access).

------
https://chatgpt.com/codex/tasks/task_e_6863a6d9ad3c83338a0badf0c8eaa23a