### PR TITLE
Document running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Signing requires a few environment variables:
 
 Set these variables in your shell or CI environment before running `cargo run --package packaging --bin packager`.
 
+## Running Tests
+
+Unit tests mock external services using environment variables. Run `cargo test` and everything should pass without Google credentials.
+
+
 ## 📄 License
 
 MIT - See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- update README with a new section describing how tests run without credentials

## Testing
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6863bc8bb42c83338a08c99bce0573c9