### PR TITLE
Add installer improvements and env docs

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -111,6 +111,7 @@ The application and packaging scripts rely on several environment variables:
 - `WINDOWS_CERT` and `WINDOWS_CERT_PASSWORD` – Path and password for a Windows code signing certificate (optional).
 - `LINUX_SIGN_KEY` – GPG key ID used to sign the generated `.deb` package (optional).
 - `MOCK_REFRESH_TOKEN` – Used only for automated tests to bypass live authentication.
+- `MOCK_COMMANDS` – Skips running external tools during packaging tests.
 
 ### Packaging installers
 Run the packager binary to create platform specific artifacts. The version is

--- a/packaging/installer.nsi
+++ b/packaging/installer.nsi
@@ -39,6 +39,7 @@ Section "Main"
   CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\googlepicz.exe"
   WriteRegStr HKLM "Software\${APP_NAME}" "InstallDir" "$INSTDIR"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "DisplayName" "${APP_NAME} ${APP_VERSION}"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "DisplayVersion" "${APP_VERSION}"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "UninstallString" "$INSTDIR\Uninstall.exe"
   WriteUninstaller "$INSTDIR\Uninstall.exe"
 SectionEnd


### PR DESCRIPTION
## Summary
- include `DisplayVersion` in `installer.nsi`
- document `MOCK_COMMANDS` environment variable used for packaging tests

## Testing
- `cargo fmt --all` *(fails: rustfmt missing)*
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6863bc902a948333a71f2acffec0e813