### PR TITLE
Remove trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img src="logo/image.png" alt="GooglePicz Logo" width="200" style="border-radius: 20px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
-  
+
   # 🖼️ GooglePicz
 
   [![Rust](https://img.shields.io/badge/Rust-1.70+-orange?logo=rust)](https://www.rust-lang.org/)

--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -146,7 +146,7 @@ impl ApiClient {
             let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
             return Err(ApiClientError::GoogleApiError(error_text));
         }
-        
+
         let list_response = response.json::<ListMediaItemsResponse>().await
             .map_err(|e| ApiClientError::RequestError(e.to_string()))?;
 
@@ -215,7 +215,7 @@ impl ApiClient {
             .send()
             .await
             .map_err(|e| ApiClientError::RequestError(e.to_string()))?;
-            
+
         if !response.status().is_success() {
             let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
             return Err(ApiClientError::GoogleApiError(error_text));

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     info!("🚀 Starting GooglePicz - Google Photos Manager");
-    
+
     // Ensure environment variables are set for client ID and secret
     if std::env::var("GOOGLE_CLIENT_ID").is_err() || std::env::var("GOOGLE_CLIENT_SECRET").is_err() {
         error!("❌ Error: GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET environment variables must be set.");
@@ -49,9 +49,9 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
     let cache_dir = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".googlepicz");
-    
+
     let db_path = cache_dir.join("cache.sqlite");
-    
+
     // Ensure the directory exists
     if let Some(parent) = db_path.parent() {
         fs::create_dir_all(parent).await?;

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -160,7 +160,7 @@ docker push ghcr.io/christopher-schulze/googlepicz-ci:latest
 
 The GitHub Actions workflow references this image to ensure consistent dependencies across CI runs.
 
-## 📝 Next Steps 
+## 📝 Next Steps
 ### Short-term Goals
 1. Complete basic photo viewing functionality
 2. Implement album management

--- a/ui/src/image_loader.rs
+++ b/ui/src/image_loader.rs
@@ -25,10 +25,10 @@ impl ImageLoader {
 
         // Create thumbnail URL (150x150 pixels)
         let thumbnail_url = format!("{}=w150-h150-c", base_url);
-        
+
         // Check if cached on disk
         let cache_path = self.cache_dir.join("thumbnails").join(format!("{}.jpg", media_id));
-        
+
         if cache_path.exists() {
             let handle = Handle::from_path(&cache_path);
             return Ok(handle);
@@ -48,7 +48,7 @@ impl ImageLoader {
 
         // Create handle
         let handle = Handle::from_path(&cache_path);
-        
+
         Ok(handle)
     }
 


### PR DESCRIPTION
## Summary
- clean up trailing whitespace in source and docs

## Testing
- `cargo test --no-run`
- ❌ `cargo fmt` (failed to install rustfmt)

------
https://chatgpt.com/codex/tasks/task_e_6863c35a118c833383d9f0f553fc9572