### PR TITLE
Apply rustfmt and trim whitespace

### DIFF
--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -1,18 +1,23 @@
-use clap::{Parser, Subcommand};
-use std::path::PathBuf;
-use dirs::home_dir;
-use tokio::sync::mpsc;
-use sync::{Syncer, SyncProgress};
 use cache::CacheManager;
-use tracing_subscriber::EnvFilter;
+use clap::{Parser, Subcommand};
+use dirs::home_dir;
+use std::path::PathBuf;
+use sync::{SyncProgress, Syncer};
+use tokio::sync::mpsc;
 use tracing_appender::rolling;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
+use tracing_subscriber::EnvFilter;
 
 #[path = "../config.rs"]
 mod config;
 
 #[derive(Parser)]
-#[command(name = "sync_cli", author, version, about = "GooglePicz synchronization CLI")]
+#[command(
+    name = "sync_cli",
+    author,
+    version,
+    about = "GooglePicz synchronization CLI"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -91,7 +96,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let cache = CacheManager::new(&db_path)?;
             let albums = cache.get_all_albums()?;
             for album in albums {
-                let title = album.title.clone().unwrap_or_else(|| "Untitled".to_string());
+                let title = album
+                    .title
+                    .clone()
+                    .unwrap_or_else(|| "Untitled".to_string());
                 println!("{} (id: {})", title, album.id);
             }
         }

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -19,15 +19,9 @@ impl AppConfig {
         let log_level = cfg
             .get_string("log_level")
             .unwrap_or_else(|_| "info".to_string());
-        let oauth_redirect_port = cfg
-            .get_int("oauth_redirect_port")
-            .unwrap_or(8080) as u16;
-        let thumbnails_preload = cfg
-            .get_int("thumbnails_preload")
-            .unwrap_or(20) as usize;
-        let sync_interval_minutes = cfg
-            .get_int("sync_interval_minutes")
-            .unwrap_or(5) as u64;
+        let oauth_redirect_port = cfg.get_int("oauth_redirect_port").unwrap_or(8080) as u16;
+        let thumbnails_preload = cfg.get_int("thumbnails_preload").unwrap_or(20) as usize;
+        let sync_interval_minutes = cfg.get_int("sync_interval_minutes").unwrap_or(5) as u64;
 
         Self {
             log_level,

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,16 +1,16 @@
 //! Main application entry point for GooglePicz.
 
 use auth::{authenticate, get_access_token};
-use sync::Syncer;
-use tokio::time::Duration;
-use tokio::task::LocalSet;
-use ui;
 use std::path::PathBuf;
+use sync::Syncer;
 use tokio::fs;
+use tokio::task::LocalSet;
+use tokio::time::Duration;
 use tracing::{error, info};
-use tracing_subscriber::EnvFilter;
 use tracing_appender::rolling;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
+use tracing_subscriber::EnvFilter;
+use ui;
 mod config;
 
 #[tokio::main]
@@ -36,7 +36,8 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
     info!("🚀 Starting GooglePicz - Google Photos Manager");
 
     // Ensure environment variables are set for client ID and secret
-    if std::env::var("GOOGLE_CLIENT_ID").is_err() || std::env::var("GOOGLE_CLIENT_SECRET").is_err() {
+    if std::env::var("GOOGLE_CLIENT_ID").is_err() || std::env::var("GOOGLE_CLIENT_SECRET").is_err()
+    {
         error!("❌ Error: GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET environment variables must be set.");
         error!("📝 Please visit https://console.developers.google.com/ to create OAuth 2.0 credentials.");
         error!("💡 Set them using:");

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -1,11 +1,11 @@
 //! Cache module for Google Photos data.
 
+use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
-use rusqlite_migration::{M, Migrations};
-use std::path::Path;
+use rusqlite_migration::{Migrations, M};
 use std::error::Error;
 use std::fmt;
-use chrono::{DateTime, Utc};
+use std::path::Path;
 
 #[derive(Debug)]
 pub enum CacheError {
@@ -129,8 +129,7 @@ fn apply_migrations(conn: &mut Connection) -> Result<(), CacheError> {
     ]);
     migrations
         .to_latest(conn)
-        .map_err(|e| CacheError::DatabaseError(format!("Failed to apply migrations: {}", e)))?
-        ;
+        .map_err(|e| CacheError::DatabaseError(format!("Failed to apply migrations: {}", e)))?;
     Ok(())
 }
 
@@ -172,14 +171,16 @@ impl CacheManager {
                     item.filename
                 ],
             )
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to insert media item: {}", e)))?;
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to insert media item: {}", e))
+            })?;
 
         self.conn
             .execute(
                 "INSERT OR REPLACE INTO media_metadata (
                     media_item_id, creation_time, width, height
                 ) VALUES (?1, ?2, ?3, ?4)",
-                params![ item.id, creation_ts, width, height ],
+                params![item.id, creation_ts, width, height],
             )
             .map_err(|e| CacheError::DatabaseError(format!("Failed to insert metadata: {}", e)))?;
 
@@ -205,26 +206,50 @@ impl CacheManager {
             .map_err(|e| CacheError::DatabaseError(format!("Failed to get row: {}", e)))?
         {
             let item = api_client::MediaItem {
-                id: row.get(0).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
-                description: row.get(1).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
-                product_url: row.get(2).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
-                base_url: row.get(3).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
-                mime_type: row.get(4).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                id: row
+                    .get(0)
+                    .map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                description: row
+                    .get(1)
+                    .map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                product_url: row
+                    .get(2)
+                    .map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                base_url: row
+                    .get(3)
+                    .map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                mime_type: row
+                    .get(4)
+                    .map_err(|e| CacheError::DatabaseError(e.to_string()))?,
                 media_metadata: api_client::MediaMetadata {
                     creation_time: {
-                        let ts: i64 = row.get(5).map_err(|e| CacheError::DatabaseError(e.to_string()))?;
-                        DateTime::<Utc>::from_utc(chrono::NaiveDateTime::from_timestamp_opt(ts, 0).ok_or_else(|| CacheError::DeserializationError("invalid timestamp".into()))?, Utc).to_rfc3339()
+                        let ts: i64 = row
+                            .get(5)
+                            .map_err(|e| CacheError::DatabaseError(e.to_string()))?;
+                        DateTime::<Utc>::from_utc(
+                            chrono::NaiveDateTime::from_timestamp_opt(ts, 0).ok_or_else(|| {
+                                CacheError::DeserializationError("invalid timestamp".into())
+                            })?,
+                            Utc,
+                        )
+                        .to_rfc3339()
                     },
                     width: {
-                        let w: i64 = row.get(6).map_err(|e| CacheError::DatabaseError(e.to_string()))?;
+                        let w: i64 = row
+                            .get(6)
+                            .map_err(|e| CacheError::DatabaseError(e.to_string()))?;
                         w.to_string()
                     },
                     height: {
-                        let h: i64 = row.get(7).map_err(|e| CacheError::DatabaseError(e.to_string()))?;
+                        let h: i64 = row
+                            .get(7)
+                            .map_err(|e| CacheError::DatabaseError(e.to_string()))?;
                         h.to_string()
                     },
                 },
-                filename: row.get(8).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                filename: row
+                    .get(8)
+                    .map_err(|e| CacheError::DatabaseError(e.to_string()))?,
             };
             Ok(Some(item))
         } else {
@@ -254,27 +279,38 @@ impl CacheManager {
                     base_url: row.get(3)?,
                     mime_type: row.get(4)?,
                     media_metadata: api_client::MediaMetadata {
-                        creation_time: DateTime::<Utc>::from_utc(chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(), Utc).to_rfc3339(),
+                        creation_time: DateTime::<Utc>::from_utc(
+                            chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(),
+                            Utc,
+                        )
+                        .to_rfc3339(),
                         width: w.to_string(),
                         height: h.to_string(),
                     },
                     filename: row.get(8)?,
                 })
             })
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to query all media items: {}", e)))?;
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to query all media items: {}", e))
+            })?;
 
         let mut items = Vec::new();
         for item_result in media_item_iter {
-            items.push(
-                item_result
-                    .map_err(|e| CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e)))?,
-            );
+            items.push(item_result.map_err(|e| {
+                CacheError::DatabaseError(format!(
+                    "Failed to retrieve media item from iterator: {}",
+                    e
+                ))
+            })?);
         }
         Ok(items)
     }
 
     /// Retrieve all media items matching the given MIME type.
-    pub fn get_media_items_by_mime_type(&self, mime: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
+    pub fn get_media_items_by_mime_type(
+        &self,
+        mime: &str,
+    ) -> Result<Vec<api_client::MediaItem>, CacheError> {
         let mut stmt = self.conn
             .prepare(
                 "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
@@ -296,24 +332,38 @@ impl CacheManager {
                     base_url: row.get(3)?,
                     mime_type: row.get(4)?,
                     media_metadata: api_client::MediaMetadata {
-                        creation_time: DateTime::<Utc>::from_utc(chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(), Utc).to_rfc3339(),
+                        creation_time: DateTime::<Utc>::from_utc(
+                            chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(),
+                            Utc,
+                        )
+                        .to_rfc3339(),
                         width: w.to_string(),
                         height: h.to_string(),
                     },
                     filename: row.get(8)?,
                 })
             })
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items: {}", e)))?;
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to query media items: {}", e))
+            })?;
 
         let mut items = Vec::new();
         for item in iter {
-            items.push(item.map_err(|e| CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e)))?);
+            items.push(item.map_err(|e| {
+                CacheError::DatabaseError(format!(
+                    "Failed to retrieve media item from iterator: {}",
+                    e
+                ))
+            })?);
         }
         Ok(items)
     }
 
     /// Retrieve media items where the filename contains the given pattern.
-    pub fn get_media_items_by_filename(&self, pattern: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
+    pub fn get_media_items_by_filename(
+        &self,
+        pattern: &str,
+    ) -> Result<Vec<api_client::MediaItem>, CacheError> {
         let like_pattern = format!("%{}%", pattern);
         let mut stmt = self.conn
             .prepare(
@@ -336,18 +386,29 @@ impl CacheManager {
                     base_url: row.get(3)?,
                     mime_type: row.get(4)?,
                     media_metadata: api_client::MediaMetadata {
-                        creation_time: DateTime::<Utc>::from_utc(chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(), Utc).to_rfc3339(),
+                        creation_time: DateTime::<Utc>::from_utc(
+                            chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(),
+                            Utc,
+                        )
+                        .to_rfc3339(),
                         width: w.to_string(),
                         height: h.to_string(),
                     },
                     filename: row.get(8)?,
                 })
             })
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items: {}", e)))?;
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to query media items: {}", e))
+            })?;
 
         let mut items = Vec::new();
         for item in iter {
-            items.push(item.map_err(|e| CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e)))?);
+            items.push(item.map_err(|e| {
+                CacheError::DatabaseError(format!(
+                    "Failed to retrieve media item from iterator: {}",
+                    e
+                ))
+            })?);
         }
         Ok(items)
     }
@@ -387,9 +448,7 @@ impl CacheManager {
                     id: row.get(0)?,
                     title: row.get(1)?,
                     product_url: row.get(2)?,
-                    is_writeable: row
-                        .get::<_, Option<i64>>(3)?
-                        .map(|v| v != 0),
+                    is_writeable: row.get::<_, Option<i64>>(3)?.map(|v| v != 0),
                     media_items_count: row.get(4)?,
                     cover_photo_base_url: row.get(5)?,
                     cover_photo_media_item_id: row.get(6)?,
@@ -399,12 +458,18 @@ impl CacheManager {
 
         let mut albums = Vec::new();
         for album in iter {
-            albums.push(album.map_err(|e| CacheError::DatabaseError(format!("Failed to retrieve album: {}", e)))?);
+            albums.push(album.map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to retrieve album: {}", e))
+            })?);
         }
         Ok(albums)
     }
 
-    pub fn associate_media_item_with_album(&self, media_item_id: &str, album_id: &str) -> Result<(), CacheError> {
+    pub fn associate_media_item_with_album(
+        &self,
+        media_item_id: &str,
+        album_id: &str,
+    ) -> Result<(), CacheError> {
         self.conn
             .execute(
                 "INSERT OR REPLACE INTO album_media_items (album_id, media_item_id) VALUES (?1, ?2)",
@@ -414,7 +479,10 @@ impl CacheManager {
         Ok(())
     }
 
-    pub fn get_media_items_by_album(&self, album_id: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
+    pub fn get_media_items_by_album(
+        &self,
+        album_id: &str,
+    ) -> Result<Vec<api_client::MediaItem>, CacheError> {
         let mut stmt = self.conn
             .prepare(
                 "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
@@ -437,18 +505,29 @@ impl CacheManager {
                     base_url: row.get(3)?,
                     mime_type: row.get(4)?,
                     media_metadata: api_client::MediaMetadata {
-                        creation_time: DateTime::<Utc>::from_utc(chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(), Utc).to_rfc3339(),
+                        creation_time: DateTime::<Utc>::from_utc(
+                            chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(),
+                            Utc,
+                        )
+                        .to_rfc3339(),
                         width: w.to_string(),
                         height: h.to_string(),
                     },
                     filename: row.get(8)?,
                 })
             })
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items by album: {}", e)))?;
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to query media items by album: {}", e))
+            })?;
 
         let mut items = Vec::new();
         for item in iter {
-            items.push(item.map_err(|e| CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e)))?);
+            items.push(item.map_err(|e| {
+                CacheError::DatabaseError(format!(
+                    "Failed to retrieve media item from iterator: {}",
+                    e
+                ))
+            })?);
         }
         Ok(items)
     }
@@ -479,38 +558,56 @@ impl CacheManager {
                     base_url: row.get(3)?,
                     mime_type: row.get(4)?,
                     media_metadata: api_client::MediaMetadata {
-                        creation_time: DateTime::<Utc>::from_utc(chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(), Utc).to_rfc3339(),
+                        creation_time: DateTime::<Utc>::from_utc(
+                            chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap(),
+                            Utc,
+                        )
+                        .to_rfc3339(),
                         width: w.to_string(),
                         height: h.to_string(),
                     },
                     filename: row.get(8)?,
                 })
             })
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items by date: {}", e)))?;
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to query media items by date: {}", e))
+            })?;
 
         let mut items = Vec::new();
         for item in iter {
-            items.push(item.map_err(|e| CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e)))?);
+            items.push(item.map_err(|e| {
+                CacheError::DatabaseError(format!(
+                    "Failed to retrieve media item from iterator: {}",
+                    e
+                ))
+            })?);
         }
         Ok(items)
     }
 
     pub fn delete_media_item(&self, id: &str) -> Result<(), CacheError> {
-        self.conn.execute("DELETE FROM media_items WHERE id = ?1", params![id])
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to delete media item: {}", e)))?;
+        self.conn
+            .execute("DELETE FROM media_items WHERE id = ?1", params![id])
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to delete media item: {}", e))
+            })?;
         Ok(())
     }
 
     pub fn clear_cache(&self) -> Result<(), CacheError> {
-        self.conn.execute("DELETE FROM media_items", [])
+        self.conn
+            .execute("DELETE FROM media_items", [])
             .map_err(|e| CacheError::DatabaseError(format!("Failed to clear cache: {}", e)))?;
         Ok(())
     }
 
     pub fn get_last_sync(&self) -> Result<DateTime<Utc>, CacheError> {
-        let mut stmt = self.conn
+        let mut stmt = self
+            .conn
             .prepare("SELECT timestamp FROM last_sync WHERE id = 1")
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to prepare statement: {}", e)))?;
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to prepare statement: {}", e))
+            })?;
         let ts: String = stmt
             .query_row([], |row| row.get(0))
             .map_err(|e| CacheError::DatabaseError(format!("Failed to query last sync: {}", e)))?;
@@ -534,9 +631,9 @@ impl CacheManager {
 mod tests {
     use super::*;
     use api_client::{Album, MediaItem, MediaMetadata};
+    use chrono::{DateTime, Utc};
     use rusqlite::Connection;
     use tempfile::NamedTempFile;
-    use chrono::{DateTime, Utc};
 
     fn create_test_media_item(id: &str) -> MediaItem {
         MediaItem {
@@ -569,16 +666,24 @@ mod tests {
         let cache_manager = CacheManager::new(db_path).expect("Failed to create cache manager");
 
         let item1 = create_test_media_item("id1");
-        cache_manager.insert_media_item(&item1).expect("Failed to insert item1");
+        cache_manager
+            .insert_media_item(&item1)
+            .expect("Failed to insert item1");
 
-        let retrieved_item = cache_manager.get_media_item("id1").expect("Failed to get item1");
+        let retrieved_item = cache_manager
+            .get_media_item("id1")
+            .expect("Failed to get item1");
         assert!(retrieved_item.is_some());
         assert_eq!(retrieved_item.unwrap().id, item1.id);
 
         let item2 = create_test_media_item("id2");
-        cache_manager.insert_media_item(&item2).expect("Failed to insert item2");
+        cache_manager
+            .insert_media_item(&item2)
+            .expect("Failed to insert item2");
 
-        let retrieved_item_none = cache_manager.get_media_item("nonexistent_id").expect("Failed to get nonexistent item");
+        let retrieved_item_none = cache_manager
+            .get_media_item("nonexistent_id")
+            .expect("Failed to get nonexistent item");
         assert!(retrieved_item_none.is_none());
     }
 
@@ -591,10 +696,16 @@ mod tests {
         let item1 = create_test_media_item("id1");
         let item2 = create_test_media_item("id2");
 
-        cache_manager.insert_media_item(&item1).expect("Failed to insert item1");
-        cache_manager.insert_media_item(&item2).expect("Failed to insert item2");
+        cache_manager
+            .insert_media_item(&item1)
+            .expect("Failed to insert item1");
+        cache_manager
+            .insert_media_item(&item2)
+            .expect("Failed to insert item2");
 
-        let all_items = cache_manager.get_all_media_items().expect("Failed to get all items");
+        let all_items = cache_manager
+            .get_all_media_items()
+            .expect("Failed to get all items");
         assert_eq!(all_items.len(), 2);
         assert!(all_items.iter().any(|i| i.id == item1.id));
         assert!(all_items.iter().any(|i| i.id == item2.id));
@@ -613,8 +724,12 @@ mod tests {
         item2.mime_type = "image/jpeg".to_string();
         item2.filename = "family.jpg".to_string();
 
-        cache_manager.insert_media_item(&item1).expect("Failed to insert item1");
-        cache_manager.insert_media_item(&item2).expect("Failed to insert item2");
+        cache_manager
+            .insert_media_item(&item1)
+            .expect("Failed to insert item1");
+        cache_manager
+            .insert_media_item(&item2)
+            .expect("Failed to insert item2");
 
         let png_items = cache_manager
             .get_media_items_by_mime_type("image/png")
@@ -644,14 +759,20 @@ mod tests {
             cover_photo_base_url: None,
             cover_photo_media_item_id: None,
         };
-        cache_manager.insert_album(&album).expect("Failed to insert album");
+        cache_manager
+            .insert_album(&album)
+            .expect("Failed to insert album");
 
         let item1 = create_test_media_item("id1");
         let mut item2 = create_test_media_item("id2");
         item2.media_metadata.creation_time = "2023-02-01T12:00:00Z".to_string();
 
-        cache_manager.insert_media_item(&item1).expect("Failed to insert item1");
-        cache_manager.insert_media_item(&item2).expect("Failed to insert item2");
+        cache_manager
+            .insert_media_item(&item1)
+            .expect("Failed to insert item1");
+        cache_manager
+            .insert_media_item(&item2)
+            .expect("Failed to insert item2");
         cache_manager
             .associate_media_item_with_album("id1", "a1")
             .expect("Failed to associate");
@@ -690,9 +811,13 @@ mod tests {
             cover_photo_base_url: None,
             cover_photo_media_item_id: None,
         };
-        cache_manager.insert_album(&album).expect("Failed to insert album");
+        cache_manager
+            .insert_album(&album)
+            .expect("Failed to insert album");
 
-        let albums = cache_manager.get_all_albums().expect("Failed to get albums");
+        let albums = cache_manager
+            .get_all_albums()
+            .expect("Failed to get albums");
         assert_eq!(albums.len(), 1);
         assert_eq!(albums[0].id, album.id);
     }
@@ -704,10 +829,16 @@ mod tests {
         let cache_manager = CacheManager::new(db_path).expect("Failed to create cache manager");
 
         let item1 = create_test_media_item("id1");
-        cache_manager.insert_media_item(&item1).expect("Failed to insert item1");
+        cache_manager
+            .insert_media_item(&item1)
+            .expect("Failed to insert item1");
 
-        cache_manager.delete_media_item("id1").expect("Failed to delete item1");
-        let retrieved_item = cache_manager.get_media_item("id1").expect("Failed to get item1 after deletion");
+        cache_manager
+            .delete_media_item("id1")
+            .expect("Failed to delete item1");
+        let retrieved_item = cache_manager
+            .get_media_item("id1")
+            .expect("Failed to get item1 after deletion");
         assert!(retrieved_item.is_none());
     }
 
@@ -720,11 +851,17 @@ mod tests {
         let item1 = create_test_media_item("id1");
         let item2 = create_test_media_item("id2");
 
-        cache_manager.insert_media_item(&item1).expect("Failed to insert item1");
-        cache_manager.insert_media_item(&item2).expect("Failed to insert item2");
+        cache_manager
+            .insert_media_item(&item1)
+            .expect("Failed to insert item1");
+        cache_manager
+            .insert_media_item(&item2)
+            .expect("Failed to insert item2");
 
         cache_manager.clear_cache().expect("Failed to clear cache");
-        let all_items = cache_manager.get_all_media_items().expect("Failed to get all items after clear");
+        let all_items = cache_manager
+            .get_all_media_items()
+            .expect("Failed to get all items after clear");
         assert!(all_items.is_empty());
     }
 
@@ -748,19 +885,21 @@ mod tests {
                     filename TEXT NOT NULL
                 )",
                 [],
-            ).unwrap();
-            conn.execute(
-                "CREATE TABLE schema_version (version INTEGER NOT NULL)",
-                [],
-            ).unwrap();
-            conn.execute("INSERT INTO schema_version (version) VALUES (1)", []).unwrap();
+            )
+            .unwrap();
+            conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)", [])
+                .unwrap();
+            conn.execute("INSERT INTO schema_version (version) VALUES (1)", [])
+                .unwrap();
             conn.pragma_update(None, "user_version", &1).unwrap();
         }
 
         let _cm = CacheManager::new(db_path).expect("Failed to open cache manager");
 
         let conn = Connection::open(db_path).unwrap();
-        let version: i32 = conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0)).unwrap();
+        let version: i32 = conn
+            .query_row("SELECT version FROM schema_version", [], |r| r.get(0))
+            .unwrap();
         assert_eq!(version, 6);
 
         let mut stmt = conn.prepare("PRAGMA table_info(media_items)").unwrap();
@@ -771,23 +910,42 @@ mod tests {
             .collect();
         assert!(cols.contains(&"is_favorite".to_string()));
 
-        let mut stmt = conn.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='last_sync'").unwrap();
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='last_sync'")
+            .unwrap();
         let has_table: Option<String> = stmt.query_row([], |row| row.get(0)).ok();
         assert!(has_table.is_some());
 
-        let mut stmt = conn.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='albums'").unwrap();
-        assert!(stmt.query_row([], |row| row.get::<_, String>(0)).ok().is_some());
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='albums'")
+            .unwrap();
+        assert!(stmt
+            .query_row([], |row| row.get::<_, String>(0))
+            .ok()
+            .is_some());
 
-        let mut stmt = conn.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='media_metadata'").unwrap();
-        assert!(stmt.query_row([], |row| row.get::<_, String>(0)).ok().is_some());
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='media_metadata'")
+            .unwrap();
+        assert!(stmt
+            .query_row([], |row| row.get::<_, String>(0))
+            .ok()
+            .is_some());
 
         let mut stmt = conn.prepare("PRAGMA table_info(media_metadata)").unwrap();
         let cols: Vec<(String, String)> = stmt
-            .query_map([], |row| Ok((row.get::<_, String>(1)?, row.get::<_, String>(2)?)))
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+            })
             .unwrap()
             .map(|r| r.unwrap())
             .collect();
-        let ct_type = cols.iter().find(|(n, _)| n == "creation_time").unwrap().1.clone();
+        let ct_type = cols
+            .iter()
+            .find(|(n, _)| n == "creation_time")
+            .unwrap()
+            .1
+            .clone();
         assert_eq!(ct_type.to_uppercase(), "INTEGER");
     }
 
@@ -812,16 +970,17 @@ mod tests {
                     is_favorite INTEGER NOT NULL DEFAULT 0
                 )",
                 [],
-            ).unwrap();
+            )
+            .unwrap();
             conn.execute(
                 "CREATE TABLE last_sync (id INTEGER PRIMARY KEY, timestamp TEXT NOT NULL)",
                 [],
-            ).unwrap();
-            conn.execute(
-                "CREATE TABLE schema_version (version INTEGER NOT NULL)",
-                [],
-            ).unwrap();
-            conn.execute("INSERT INTO schema_version (version) VALUES (3)", []).unwrap();
+            )
+            .unwrap();
+            conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)", [])
+                .unwrap();
+            conn.execute("INSERT INTO schema_version (version) VALUES (3)", [])
+                .unwrap();
             conn.pragma_update(None, "user_version", &3).unwrap();
         }
 
@@ -847,11 +1006,18 @@ mod tests {
 
         let mut stmt = conn.prepare("PRAGMA table_info(media_metadata)").unwrap();
         let cols: Vec<(String, String)> = stmt
-            .query_map([], |row| Ok((row.get::<_, String>(1)?, row.get::<_, String>(2)?)))
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+            })
             .unwrap()
             .map(|r| r.unwrap())
             .collect();
-        let ct_type = cols.iter().find(|(n, _)| n == "creation_time").unwrap().1.clone();
+        let ct_type = cols
+            .iter()
+            .find(|(n, _)| n == "creation_time")
+            .unwrap()
+            .1
+            .clone();
         assert_eq!(ct_type.to_uppercase(), "INTEGER");
     }
 
@@ -861,13 +1027,19 @@ mod tests {
         let db_path = temp_file.path();
         let cache_manager = CacheManager::new(db_path).expect("Failed to create cache manager");
 
-        let ts = cache_manager.get_last_sync().expect("Failed to get last sync");
+        let ts = cache_manager
+            .get_last_sync()
+            .expect("Failed to get last sync");
         assert_eq!(ts, DateTime::<Utc>::from(std::time::SystemTime::UNIX_EPOCH));
 
         let now = Utc::now();
-        cache_manager.update_last_sync(now).expect("Failed to update last sync");
+        cache_manager
+            .update_last_sync(now)
+            .expect("Failed to update last sync");
 
-        let new_ts = cache_manager.get_last_sync().expect("Failed to read updated last sync");
+        let new_ts = cache_manager
+            .get_last_sync()
+            .expect("Failed to read updated last sync");
         assert!(new_ts >= now);
     }
 }

--- a/packaging/src/main.rs
+++ b/packaging/src/main.rs
@@ -2,4 +2,3 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     packaging::package_all()?;
     Ok(())
 }
-

--- a/ui/src/image_loader.rs
+++ b/ui/src/image_loader.rs
@@ -1,10 +1,10 @@
 //! Image loading and caching functionality for GooglePicz UI.
 
+use api_client;
+use iced::widget::image::Handle;
+use reqwest;
 use std::path::PathBuf;
 use tokio::fs;
-use reqwest;
-use iced::widget::image::Handle;
-use api_client;
 
 #[derive(Debug, Clone)]
 pub struct ImageLoader {
@@ -15,19 +15,22 @@ pub struct ImageLoader {
 impl ImageLoader {
     pub fn new(cache_dir: PathBuf) -> Self {
         let client = reqwest::Client::new();
-        Self {
-            cache_dir,
-            client,
-        }
+        Self { cache_dir, client }
     }
 
-    pub async fn load_thumbnail(&self, media_id: &str, base_url: &str) -> Result<Handle, Box<dyn std::error::Error>> {
-
+    pub async fn load_thumbnail(
+        &self,
+        media_id: &str,
+        base_url: &str,
+    ) -> Result<Handle, Box<dyn std::error::Error>> {
         // Create thumbnail URL (150x150 pixels)
         let thumbnail_url = format!("{}=w150-h150-c", base_url);
 
         // Check if cached on disk
-        let cache_path = self.cache_dir.join("thumbnails").join(format!("{}.jpg", media_id));
+        let cache_path = self
+            .cache_dir
+            .join("thumbnails")
+            .join(format!("{}.jpg", media_id));
 
         if cache_path.exists() {
             let handle = Handle::from_path(&cache_path);
@@ -52,9 +55,16 @@ impl ImageLoader {
         Ok(handle)
     }
 
-    pub async fn load_full_image(&self, media_id: &str, base_url: &str) -> Result<Handle, Box<dyn std::error::Error>> {
+    pub async fn load_full_image(
+        &self,
+        media_id: &str,
+        base_url: &str,
+    ) -> Result<Handle, Box<dyn std::error::Error>> {
         let full_url = format!("{}=d", base_url);
-        let cache_path = self.cache_dir.join("full").join(format!("{}.jpg", media_id));
+        let cache_path = self
+            .cache_dir
+            .join("full")
+            .join(format!("{}.jpg", media_id));
 
         if cache_path.exists() {
             return Ok(Handle::from_path(&cache_path));

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -2,27 +2,26 @@
 
 mod image_loader;
 
-use iced::widget::{
-    button, column, container, text, scrollable, row, image, text_input, pick_list,
-    Column
-};
-use iced::widget::image::Handle;
-use iced::{executor, Application, Command, Element, Length, Settings, Theme, Subscription};
+use api_client::{Album, ApiClient, MediaItem};
+use auth;
+use cache::CacheManager;
+use chrono::{DateTime, Utc};
 use iced::subscription;
-use tokio::time::{sleep, Duration};
-use iced::{Color};
 use iced::widget::container::Appearance;
+use iced::widget::image::Handle;
+use iced::widget::{
+    button, column, container, image, pick_list, row, scrollable, text, text_input, Column,
+};
 use iced::Border;
+use iced::Color;
+use iced::{executor, Application, Command, Element, Length, Settings, Subscription, Theme};
+use image_loader::ImageLoader;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::Mutex;
-use cache::CacheManager;
-use api_client::{MediaItem, Album, ApiClient};
-use auth;
-use image_loader::ImageLoader;
-use tokio::sync::mpsc;
 use sync::SyncProgress;
-use chrono::{DateTime, Utc};
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration};
 
 const ERROR_DISPLAY_DURATION: Duration = Duration::from_secs(5);
 
@@ -39,7 +38,10 @@ fn error_container_style() -> iced::theme::Container {
     }))
 }
 
-pub fn run(progress: Option<mpsc::UnboundedReceiver<SyncProgress>>, preload: usize) -> iced::Result {
+pub fn run(
+    progress: Option<mpsc::UnboundedReceiver<SyncProgress>>,
+    preload: usize,
+) -> iced::Result {
     GooglePiczUI::run(Settings::with_flags((progress, preload)))
 }
 
@@ -110,9 +112,12 @@ pub struct GooglePiczUI {
 
 impl GooglePiczUI {
     fn error_timeout() -> Command<Message> {
-        Command::perform(async {
-            sleep(ERROR_DISPLAY_DURATION).await;
-        }, |_| Message::ClearErrors)
+        Command::perform(
+            async {
+                sleep(ERROR_DISPLAY_DURATION).await;
+            },
+            |_| Message::ClearErrors,
+        )
     }
 }
 
@@ -138,7 +143,9 @@ impl Application for GooglePiczUI {
         let last_synced = if let Some(cm) = &cache_manager {
             let cache = cm.blocking_lock();
             cache.get_last_sync().ok()
-        } else { None };
+        } else {
+            None
+        };
 
         let thumbnail_cache_path = dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("."))
@@ -189,20 +196,26 @@ impl Application for GooglePiczUI {
                 self.loading = true;
                 if let Some(album_id) = &self.selected_album {
                     let album_id = album_id.clone();
-                    return Command::perform(async move {
-                        let token = auth::ensure_access_token_valid().await.map_err(|e| e.to_string())?;
-                        let client = ApiClient::new(token);
-                        client.get_album_media_items(&album_id, 100, None).await
-                            .map(|r| r.0)
-                            .map_err(|e| e.to_string())
-                    }, Message::PhotosLoaded);
+                    return Command::perform(
+                        async move {
+                            let token = auth::ensure_access_token_valid()
+                                .await
+                                .map_err(|e| e.to_string())?;
+                            let client = ApiClient::new(token);
+                            client
+                                .get_album_media_items(&album_id, 100, None)
+                                .await
+                                .map(|r| r.0)
+                                .map_err(|e| e.to_string())
+                        },
+                        Message::PhotosLoaded,
+                    );
                 } else if let Some(cache_manager) = &self.cache_manager {
                     let cache_manager = cache_manager.clone();
                     return Command::perform(
                         async move {
                             let cache = cache_manager.lock().await;
-                            cache.get_all_media_items()
-                                .map_err(|e| e.to_string())
+                            cache.get_all_media_items().map_err(|e| e.to_string())
                         },
                         Message::PhotosLoaded,
                     );
@@ -218,34 +231,44 @@ impl Application for GooglePiczUI {
                         for photo in self.photos.iter().take(self.preload_count) {
                             let media_id = photo.id.clone();
                             let base_url = photo.base_url.clone();
-                            commands.push(Command::perform(async {}, move |_| Message::LoadThumbnail(media_id.clone(), base_url.clone())));
+                            commands.push(Command::perform(async {}, move |_| {
+                                Message::LoadThumbnail(media_id.clone(), base_url.clone())
+                            }));
                         }
                         return Command::batch(commands);
                     }
                     Err(error) => {
-                        self.errors.push(format!("Failed to load photos: {}", error));
+                        self.errors
+                            .push(format!("Failed to load photos: {}", error));
                         return GooglePiczUI::error_timeout();
                     }
                 }
             }
             Message::LoadAlbums => {
-                return Command::perform(async {
-                    let token = auth::ensure_access_token_valid().await.map_err(|e| e.to_string())?;
-                    let client = ApiClient::new(token);
-                    client.list_albums(50, None).await
-                        .map(|r| r.0)
-                        .map_err(|e| e.to_string())
-                }, Message::AlbumsLoaded);
+                return Command::perform(
+                    async {
+                        let token = auth::ensure_access_token_valid()
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        let client = ApiClient::new(token);
+                        client
+                            .list_albums(50, None)
+                            .await
+                            .map(|r| r.0)
+                            .map_err(|e| e.to_string())
+                    },
+                    Message::AlbumsLoaded,
+                );
             }
-            Message::AlbumsLoaded(result) => {
-                match result {
-                    Ok(albums) => { self.albums = albums; }
-                    Err(err) => {
-                        self.errors.push(format!("Failed to load albums: {}", err));
-                        return GooglePiczUI::error_timeout();
-                    }
+            Message::AlbumsLoaded(result) => match result {
+                Ok(albums) => {
+                    self.albums = albums;
                 }
-            }
+                Err(err) => {
+                    self.errors.push(format!("Failed to load albums: {}", err));
+                    return GooglePiczUI::error_timeout();
+                }
+            },
             Message::RefreshPhotos => {
                 return Command::batch(vec![
                     Command::perform(async {}, |_| Message::LoadPhotos),
@@ -261,28 +284,30 @@ impl Application for GooglePiczUI {
                         let loader = image_loader.lock().await;
                         loader.load_thumbnail(&id_clone, &base_clone).await
                     },
-                    move |result| Message::ThumbnailLoaded(media_id, result.map_err(|e| e.to_string())),
+                    move |result| {
+                        Message::ThumbnailLoaded(media_id, result.map_err(|e| e.to_string()))
+                    },
                 );
             }
-            Message::ThumbnailLoaded(media_id, result) => {
-                match result {
-                    Ok(handle) => {
-                        self.thumbnails.insert(media_id, handle);
-                    }
-                    Err(error) => {
-                        self.errors.push(format!(
-                            "Failed to load thumbnail for {}: {}",
-                            media_id, error
-                        ));
-                        return GooglePiczUI::error_timeout();
-                    }
+            Message::ThumbnailLoaded(media_id, result) => match result {
+                Ok(handle) => {
+                    self.thumbnails.insert(media_id, handle);
                 }
-            }
+                Err(error) => {
+                    self.errors.push(format!(
+                        "Failed to load thumbnail for {}: {}",
+                        media_id, error
+                    ));
+                    return GooglePiczUI::error_timeout();
+                }
+            },
             Message::SelectPhoto(photo) => {
                 let id = photo.id.clone();
                 let url = photo.base_url.clone();
                 self.state = ViewState::SelectedPhoto(photo);
-                return Command::perform(async {}, move |_| Message::LoadFullImage(id.clone(), url.clone()));
+                return Command::perform(async {}, move |_| {
+                    Message::LoadFullImage(id.clone(), url.clone())
+                });
             }
             Message::SelectAlbum(album_id) => {
                 self.selected_album = album_id;
@@ -300,33 +325,29 @@ impl Application for GooglePiczUI {
                     move |res| Message::FullImageLoaded(media_id, res.map_err(|e| e.to_string())),
                 );
             }
-            Message::FullImageLoaded(media_id, result) => {
-                match result {
-                    Ok(handle) => {
-                        self.full_images.insert(media_id, handle);
-                    }
-                    Err(error) => {
-                        self.errors.push(format!("Failed to load image: {}", error));
-                        return GooglePiczUI::error_timeout();
-                    }
+            Message::FullImageLoaded(media_id, result) => match result {
+                Ok(handle) => {
+                    self.full_images.insert(media_id, handle);
                 }
-            }
+                Err(error) => {
+                    self.errors.push(format!("Failed to load image: {}", error));
+                    return GooglePiczUI::error_timeout();
+                }
+            },
             Message::ClosePhoto => {
                 self.state = ViewState::Grid;
             }
-            Message::SyncProgress(progress) => {
-                match progress {
-                    SyncProgress::ItemSynced(count) => {
-                        self.synced = count;
-                        self.syncing = true;
-                    }
-                    SyncProgress::Finished(total) => {
-                        self.synced = total;
-                        self.syncing = false;
-                        self.last_synced = Some(Utc::now());
-                    }
+            Message::SyncProgress(progress) => match progress {
+                SyncProgress::ItemSynced(count) => {
+                    self.synced = count;
+                    self.syncing = true;
                 }
-            }
+                SyncProgress::Finished(total) => {
+                    self.synced = total;
+                    self.syncing = false;
+                    self.last_synced = Some(Utc::now());
+                }
+            },
             Message::DismissError(index) => {
                 if index < self.errors.len() {
                     self.errors.remove(index);
@@ -352,7 +373,9 @@ impl Application for GooglePiczUI {
                             .await
                             .map_err(|e| e.to_string())?;
                         let client = ApiClient::new(token);
-                        let album = client.create_album(&title).await
+                        let album = client
+                            .create_album(&title)
+                            .await
                             .map_err(|e| e.to_string())?;
                         if let Some(cm) = cache_manager {
                             let cache = cm.lock().await;
@@ -365,17 +388,15 @@ impl Application for GooglePiczUI {
                     Message::AlbumCreated,
                 );
             }
-            Message::AlbumCreated(result) => {
-                match result {
-                    Ok(album) => {
-                        self.albums.push(album);
-                    }
-                    Err(err) => {
-                        self.errors.push(format!("Failed to create album: {}", err));
-                        return GooglePiczUI::error_timeout();
-                    }
+            Message::AlbumCreated(result) => match result {
+                Ok(album) => {
+                    self.albums.push(album);
                 }
-            }
+                Err(err) => {
+                    self.errors.push(format!("Failed to create album: {}", err));
+                    return GooglePiczUI::error_timeout();
+                }
+            },
             Message::CancelCreateAlbum => {
                 self.creating_album = false;
                 self.new_album_title.clear();
@@ -437,12 +458,10 @@ impl Application for GooglePiczUI {
             } else {
                 format!("Synced {} items", self.synced)
             }),
-            text(
-                match self.last_synced {
-                    Some(ts) => format!("Last synced {}", ts.to_rfc3339()),
-                    None => "Never synced".to_string(),
-                }
-            )
+            text(match self.last_synced {
+                Some(ts) => format!("Last synced {}", ts.to_rfc3339()),
+                None => "Never synced".to_string(),
+            })
         ]
         .spacing(20)
         .align_items(iced::Alignment::Center);
@@ -455,11 +474,8 @@ impl Application for GooglePiczUI {
             ]
             .spacing(10)
             .align_items(iced::Alignment::Center);
-            error_column = error_column.push(
-                container(row)
-                    .style(error_container_style())
-                    .padding(10),
-            );
+            error_column =
+                error_column.push(container(row).style(error_container_style()).padding(10));
         }
         let error_banner = if self.errors.is_empty() {
             None
@@ -478,7 +494,7 @@ impl Application for GooglePiczUI {
                     ]
                     .spacing(10)
                 ]
-                .spacing(10)
+                .spacing(10),
             )
         } else {
             None
@@ -487,37 +503,42 @@ impl Application for GooglePiczUI {
         let content = match &self.state {
             ViewState::Grid => {
                 if self.loading {
-                    column![
-                        header,
-                        text("Loading photos...").size(16),
-                    ]
+                    column![header, text("Loading photos...").size(16),]
                 } else if self.photos.is_empty() {
                     column![
                         header,
                         text("No photos found. Make sure you have authenticated and synced your photos.").size(16),
                     ]
                 } else {
-                    let mut album_row = row![button(text("All")).on_press(Message::SelectAlbum(None))].spacing(10);
+                    let mut album_row =
+                        row![button(text("All")).on_press(Message::SelectAlbum(None))].spacing(10);
                     for album in &self.albums {
-                        let title = album.title.clone().unwrap_or_else(|| "Untitled".to_string());
-                        album_row = album_row.push(button(text(title)).on_press(Message::SelectAlbum(Some(album.id.clone()))));
+                        let title = album
+                            .title
+                            .clone()
+                            .unwrap_or_else(|| "Untitled".to_string());
+                        album_row = album_row.push(
+                            button(text(title))
+                                .on_press(Message::SelectAlbum(Some(album.id.clone()))),
+                        );
                     }
 
                     let mut rows = column![].spacing(10);
                     let mut current = row![].spacing(10);
                     let mut count = 0;
                     for photo in &self.photos {
-                        let thumb: Element<Message> = if let Some(handle) = self.thumbnails.get(&photo.id) {
-                            image(handle.clone())
-                                .width(Length::Fixed(150.0))
-                                .height(Length::Fixed(150.0))
-                                .into()
-                        } else {
-                            container(text("Loading...") )
-                                .width(Length::Fixed(150.0))
-                                .height(Length::Fixed(150.0))
-                                .into()
-                        };
+                        let thumb: Element<Message> =
+                            if let Some(handle) = self.thumbnails.get(&photo.id) {
+                                image(handle.clone())
+                                    .width(Length::Fixed(150.0))
+                                    .height(Length::Fixed(150.0))
+                                    .into()
+                            } else {
+                                container(text("Loading..."))
+                                    .width(Length::Fixed(150.0))
+                                    .height(Length::Fixed(150.0))
+                                    .into()
+                            };
                         let btn = button(thumb).on_press(Message::SelectPhoto(photo.clone()));
                         current = current.push(btn);
                         count += 1;
@@ -540,9 +561,15 @@ impl Application for GooglePiczUI {
             }
             ViewState::SelectedPhoto(photo) => {
                 let img: Element<Message> = if let Some(handle) = self.full_images.get(&photo.id) {
-                    image(handle.clone()).width(Length::Fill).height(Length::Fill).into()
+                    image(handle.clone())
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .into()
                 } else {
-                    container(text("Loading...")).width(Length::Fill).height(Length::Fill).into()
+                    container(text("Loading..."))
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .into()
                 };
                 let album_opts: Vec<AlbumOption> = self
                     .albums
@@ -556,15 +583,23 @@ impl Application for GooglePiczUI {
                     header,
                     button("Close").on_press(Message::ClosePhoto),
                     img,
-                    pick_list(album_opts, self.assign_selection.clone(), Message::AlbumPicked)
+                    pick_list(
+                        album_opts,
+                        self.assign_selection.clone(),
+                        Message::AlbumPicked
+                    )
                 ]
             }
         };
 
         let mut base = column![].spacing(20);
-        if let Some(b) = error_banner { base = base.push(b); }
+        if let Some(b) = error_banner {
+            base = base.push(b);
+        }
         base = base.push(content);
-        if let Some(d) = album_dialog { base = base.push(d); }
+        if let Some(d) = album_dialog {
+            base = base.push(d);
+        }
 
         container(base)
             .width(Length::Fill)


### PR DESCRIPTION
## Summary
- remove trailing whitespace in Rust and Markdown files
- run `rustfmt` to ensure consistent formatting

## Testing
- `/usr/bin/rustfmt --edition 2021`

------
https://chatgpt.com/codex/tasks/task_e_6863cb2c662c8333a43bbc78a29b2fca