### PR TITLE
docs: mention AppConfig usage in sync_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ See the following documents for additional details:
 ## Sync CLI
 
 Run the `sync_cli` binary for manual synchronization or to inspect the local cache.
+Like the GUI, it reads settings from `~/.googlepicz/config` via `AppConfig`.
 The tool exposes subcommands for `sync`, `status`, `clear-cache` and `list-albums` and prints progress updates
 to stdout while downloading items. The source code lives in
 `app/src/bin/sync_cli.rs`.

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -130,7 +130,7 @@ after creation to embed the version, mirroring the Windows installer name.
 
 ## Sync CLI
 
-In addition to the main application UI, the project provides a command line utility for manual synchronization and cache inspection. The binary lives under `app/src/bin/sync_cli.rs` and is built alongside the rest of the workspace.
+In addition to the main application UI, the project provides a command line utility for manual synchronization and cache inspection. The binary lives under `app/src/bin/sync_cli.rs` and is built alongside the rest of the workspace. It uses `AppConfig` on startup, so options defined in `~/.googlepicz/config` apply here as well.
 
 ```bash
 cargo run --package googlepicz --bin sync_cli -- sync


### PR DESCRIPTION
## Summary
- document that sync_cli reads settings from `AppConfig`

## Testing
- `cargo test -q`
- `cargo check -q`

------
https://chatgpt.com/codex/tasks/task_e_6863cb2b6d0c8333a3e95abc5513df0a