### PR TITLE
Add sync_cli integration tests

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -20,6 +20,11 @@ clap = { workspace = true }
 [build-dependencies]
 cargo-bundle-licenses = "0.4"
 
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "2"
+tempfile = "3"
+
 [profile.release]
 opt-level = "s"
 lto = true

--- a/app/tests/cli.rs
+++ b/app/tests/cli.rs
@@ -1,0 +1,44 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+#[test]
+fn sync_cli_help() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("sync_cli")?;
+    cmd.arg("--help");
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("GooglePicz synchronization CLI"));
+    Ok(())
+}
+
+#[test]
+fn sync_cli_status_no_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_home = TempDir::new()?;
+    let mut cmd = Command::cargo_bin("sync_cli")?;
+    cmd.arg("status");
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("HOME", tmp_home.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No cache found"));
+    Ok(())
+}
+
+#[test]
+fn sync_cli_list_albums_no_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_home = TempDir::new()?;
+    let mut cmd = Command::cargo_bin("sync_cli")?;
+    cmd.arg("list-albums");
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("HOME", tmp_home.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No cache found"));
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- add new CLI tests using `assert_cmd`
- include `assert_cmd`, `predicates` and `tempfile` as dev dependencies

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6863d91351d08333af7ac09776fce225