### PR TITLE
Add sync_cli integration tests

### DIFF
--- a/app/tests/sync_cli_subcommands.rs
+++ b/app/tests/sync_cli_subcommands.rs
@@ -1,0 +1,39 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::TempDir;
+
+fn build_cmd() -> Command {
+    let dir = TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("sync_cli").unwrap();
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("HOME", dir.path());
+    cmd
+}
+
+#[test]
+fn sync_cli_help_runs() {
+    build_cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(contains("GooglePicz synchronization CLI"));
+}
+
+#[test]
+fn sync_cli_status_no_cache() {
+    build_cmd()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(contains("No cache found"));
+}
+
+#[test]
+fn sync_cli_list_albums_no_cache() {
+    build_cmd()
+        .arg("list-albums")
+        .assert()
+        .success()
+        .stdout(contains("No cache found"));
+}


### PR DESCRIPTION
## Summary
- add integration tests for sync_cli subcommands

## Testing
- `cargo test --workspace sync_cli_help_runs -- --exact`


------
https://chatgpt.com/codex/tasks/task_e_6863dfd9d7348333b7b892c6d403bbb7