### PR TITLE
Ensure token validation

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,6 +1,6 @@
 //! Main application entry point for GooglePicz.
 
-use auth::{authenticate, get_access_token};
+use auth::{authenticate, ensure_access_token_valid};
 use std::path::PathBuf;
 use sync::Syncer;
 use tokio::fs;
@@ -59,8 +59,8 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
         info!("📁 Cache directory: {:?}", parent);
     }
 
-    // Check if we have a valid token
-    let needs_auth = match get_access_token() {
+    // Check if we have a valid token, refreshing if necessary
+    let needs_auth = match ensure_access_token_valid().await {
         Ok(_) => {
             info!("✅ Found existing authentication token");
             false

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -157,7 +157,7 @@ impl Syncer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use auth::{authenticate, get_access_token};
+    use auth::{authenticate, ensure_access_token_valid};
     use serial_test::serial;
     use tempfile::NamedTempFile;
 
@@ -174,7 +174,7 @@ mod tests {
         // For a real application, you'd have a proper token management system.
 
         // Attempt to authenticate if no token is found
-        if get_access_token().is_err() {
+        if ensure_access_token_valid().await.is_err() {
             authenticate(8080)
                 .await
                 .expect("Failed to authenticate for sync test");


### PR DESCRIPTION
## Summary
- validate access token in app startup using `ensure_access_token_valid`
- update sync tests to check token validity via `ensure_access_token_valid`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6864386f2e18833393eb9712591a1efe