### PR TITLE
Add thorough cache clearing test

### DIFF
--- a/cache/tests/cache_manager.rs
+++ b/cache/tests/cache_manager.rs
@@ -46,11 +46,55 @@ fn test_insert_and_query_media_item() {
 fn test_clear_cache() {
     let file = NamedTempFile::new().unwrap();
     let cm = CacheManager::new(file.path()).unwrap();
-    cm.insert_media_item(&sample_item("1")).unwrap();
-    cm.insert_media_item(&sample_item("2")).unwrap();
-    assert_eq!(cm.get_all_media_items().unwrap().len(), 2);
+
+    // Insert sample data into all relevant tables
+    let item = sample_item("1");
+    cm.insert_media_item(&item).unwrap();
+    let album = api_client::Album {
+        id: "a1".into(),
+        title: Some("Album".into()),
+        product_url: None,
+        is_writeable: None,
+        media_items_count: None,
+        cover_photo_base_url: None,
+        cover_photo_media_item_id: None,
+    };
+    cm.insert_album(&album).unwrap();
+    cm.associate_media_item_with_album(&item.id, &album.id)
+        .unwrap();
+    cm.update_last_sync(Utc::now()).unwrap();
+
+    assert_eq!(cm.get_all_media_items().unwrap().len(), 1);
+    assert_eq!(cm.get_all_albums().unwrap().len(), 1);
+    assert_eq!(
+        cm.get_media_items_by_album(&album.id).unwrap().len(),
+        1
+    );
+
     cm.clear_cache().unwrap();
-    assert!(cm.get_all_media_items().unwrap().is_empty());
+
+    // Verify all tables are empty and last_sync reset
+    let conn = Connection::open(file.path()).unwrap();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM media_items", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM media_metadata", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM albums", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM album_media_items", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+    let ts: String = conn
+        .query_row("SELECT timestamp FROM last_sync WHERE id = 1", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(ts, "1970-01-01T00:00:00Z");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend integration test to verify all tables are cleared by `clear_cache`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68643fe7aeb88333a4c8407d75efe116