### PR TITLE
Add UI integration tests

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod image_loader;
 
+pub use image_loader::ImageLoader;
+
 use api_client::{Album, ApiClient, MediaItem};
 use auth;
 use cache::CacheManager;
@@ -15,7 +17,6 @@ use iced::widget::{
 use iced::Border;
 use iced::Color;
 use iced::{executor, Application, Command, Element, Length, Settings, Subscription, Theme};
-use image_loader::ImageLoader;
 use std::path::PathBuf;
 use std::sync::Arc;
 use sync::SyncProgress;
@@ -116,6 +117,23 @@ pub struct GooglePiczUI {
 }
 
 impl GooglePiczUI {
+    /// Expose current state for testing purposes
+    pub fn state_debug(&self) -> String {
+        format!("{:?}", self.state)
+    }
+
+    /// Return number of stored errors
+    pub fn error_count(&self) -> usize {
+        self.errors.len()
+    }
+
+    pub fn photo_count(&self) -> usize {
+        self.photos.len()
+    }
+
+    pub fn album_count(&self) -> usize {
+        self.albums.len()
+    }
     fn error_timeout() -> Command<Message> {
         Command::perform(
             async {

--- a/ui/tests/image_loader.rs
+++ b/ui/tests/image_loader.rs
@@ -1,0 +1,44 @@
+use ui::ImageLoader;
+use httpmock::prelude::*;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn test_thumbnail_cached() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET).path("/img.jpg=w150-h150-c");
+        then.status(200).body("thumb");
+    });
+
+    let dir = tempdir().unwrap();
+    let loader = ImageLoader::new(dir.path().to_path_buf());
+    let url = format!("{}/img.jpg", server.url(""));
+
+    loader.load_thumbnail("1", &url).await.unwrap();
+    assert!(dir.path().join("thumbnails/1.jpg").exists());
+    mock.assert_hits(1);
+
+    // Second call should use cache
+    loader.load_thumbnail("1", &url).await.unwrap();
+    mock.assert_hits(1);
+}
+
+#[tokio::test]
+async fn test_full_image_cached() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET).path("/img.jpg=d");
+        then.status(200).body("full");
+    });
+
+    let dir = tempdir().unwrap();
+    let loader = ImageLoader::new(dir.path().to_path_buf());
+    let url = format!("{}/img.jpg", server.url(""));
+
+    loader.load_full_image("1", &url).await.unwrap();
+    assert!(dir.path().join("full/1.jpg").exists());
+    mock.assert_hits(1);
+
+    loader.load_full_image("1", &url).await.unwrap();
+    mock.assert_hits(1);
+}

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -1,0 +1,61 @@
+use ui::{GooglePiczUI, Message};
+use iced::Application;
+use tempfile::tempdir;
+use api_client::{MediaItem, MediaMetadata};
+
+fn sample_item() -> MediaItem {
+    MediaItem {
+        id: "1".to_string(),
+        description: None,
+        product_url: "http://example.com".into(),
+        base_url: "http://example.com/base".into(),
+        mime_type: "image/jpeg".into(),
+        media_metadata: MediaMetadata {
+            creation_time: "2023-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+        },
+        filename: "1.jpg".into(),
+    }
+}
+
+#[test]
+fn test_initial_state() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (ui, _) = GooglePiczUI::new((None, None, 0));
+    assert_eq!(ui.photo_count(), 0);
+    assert_eq!(ui.album_count(), 0);
+    assert_eq!(ui.state_debug(), "Grid");
+}
+
+#[test]
+fn test_select_and_close_photo() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0));
+    let item = sample_item();
+
+    let _ = ui.update(Message::SelectPhoto(item.clone()));
+    assert!(ui.state_debug().starts_with("SelectedPhoto"));
+
+    let _ = ui.update(Message::ClosePhoto);
+    assert_eq!(ui.state_debug(), "Grid");
+}
+
+#[test]
+fn test_dismiss_error() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0));
+    let _ = ui.update(Message::SyncError("err".into()));
+    assert_eq!(ui.error_count(), 1);
+    let _ = ui.update(Message::DismissError(0));
+    assert_eq!(ui.error_count(), 0);
+}


### PR DESCRIPTION
## Summary
- expose `ImageLoader` and add helper getters for tests
- add integration tests for caching behavior using `httpmock`
- add basic state tests for `GooglePiczUI`

## Testing
- `cargo test -p ui -- --nocapture`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68652fa28e148333903acd54a7c5f64f