### PR TITLE
Add indexes to cache migrations

### DIFF
--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -112,9 +112,14 @@ fn apply_migrations(conn: &mut Connection) -> Result<(), CacheError> {
              DROP TABLE media_items;\
              ALTER TABLE media_items_new RENAME TO media_items;\
              ALTER TABLE media_metadata_new RENAME TO media_metadata;\
-             ALTER TABLE album_media_items_new RENAME TO album_media_items;\
-             PRAGMA foreign_keys=on;\
-             UPDATE schema_version SET version = 6;"
+            ALTER TABLE album_media_items_new RENAME TO album_media_items;\
+            PRAGMA foreign_keys=on;\
+            UPDATE schema_version SET version = 6;"
+        ),
+        M::up(
+            "CREATE INDEX IF NOT EXISTS idx_media_metadata_creation_time ON media_metadata (creation_time);\
+             CREATE INDEX IF NOT EXISTS idx_media_items_mime_type ON media_items (mime_type);\
+             UPDATE schema_version SET version = 7;"
         ),
     ]);
     migrations

--- a/cache/tests/cache_manager.rs
+++ b/cache/tests/cache_manager.rs
@@ -28,7 +28,7 @@ fn test_new_applies_migrations() {
     let version: i64 = conn
         .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 6);
+    assert_eq!(version, 7);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- create indexes on media_metadata.creation_time and media_items.mime_type
- bump schema version in migrations
- update tests for new schema version

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6865735e1d60833396e82f1982f0ea08