### PR TITLE
Handle sync errors via channel

### DIFF
--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             });
-            syncer.sync_media_items(Some(tx)).await?;
+            syncer.sync_media_items(Some(tx), None).await?;
         }
         Commands::Status => {
             if !db_path.exists() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -106,7 +106,7 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
 
             info!("📥 Starting synchronization...");
             if ensure_access_token_valid().await.is_ok() {
-                if let Err(e) = syncer.sync_media_items(Some(tx.clone())).await {
+                if let Err(e) = syncer.sync_media_items(Some(tx.clone()), Some(err_tx.clone())).await {
                     error!("❌ Synchronization failed: {}", e);
                 }
             } else {

--- a/sync/tests/sync_flow.rs
+++ b/sync/tests/sync_flow.rs
@@ -14,7 +14,7 @@ async fn test_sync_flow_mock() {
     let file = NamedTempFile::new().unwrap();
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut syncer = Syncer::new(file.path()).await.unwrap();
-    syncer.sync_media_items(Some(tx)).await.unwrap();
+    syncer.sync_media_items(Some(tx), None).await.unwrap();
     assert!(rx.recv().await.is_some());
     let cache = CacheManager::new(file.path()).unwrap();
     let items = cache.get_all_media_items().unwrap();

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,4 +19,5 @@ chrono = { version = "0.4", features = ["serde"] }
 [dev-dependencies]
 httpmock = "0.6"
 tempfile = "3"
+serial_test = "2"
 

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -2,6 +2,7 @@ use ui::{GooglePiczUI, Message};
 use iced::Application;
 use tempfile::tempdir;
 use api_client::{MediaItem, MediaMetadata};
+use serial_test::serial;
 
 fn sample_item() -> MediaItem {
     MediaItem {
@@ -20,6 +21,7 @@ fn sample_item() -> MediaItem {
 }
 
 #[test]
+#[serial]
 fn test_initial_state() {
     let dir = tempdir().unwrap();
     std::env::set_var("HOME", dir.path());
@@ -32,6 +34,7 @@ fn test_initial_state() {
 }
 
 #[test]
+#[serial]
 fn test_select_and_close_photo() {
     let dir = tempdir().unwrap();
     std::env::set_var("HOME", dir.path());
@@ -48,6 +51,7 @@ fn test_select_and_close_photo() {
 }
 
 #[test]
+#[serial]
 fn test_dismiss_error() {
     let dir = tempdir().unwrap();
     std::env::set_var("HOME", dir.path());


### PR DESCRIPTION
## Summary
- allow `sync_media_items` to forward error messages through a channel
- propagate those messages from `start_periodic_sync`
- pass error sender from the main application and CLI
- make UI integration tests serial and add needed dev dependency

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_68662fcae26c833394d2b13479e827f4