### PR TITLE
Forward sync errors to UI

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -62,7 +62,13 @@ impl Syncer {
 
         let last_sync = match self.cache_manager.get_last_sync() {
             Ok(ts) => ts,
-            Err(_) => DateTime::<Utc>::from(std::time::SystemTime::UNIX_EPOCH),
+            Err(e) => {
+                let msg = format!("Failed to get last sync time: {}", e);
+                if let Some(tx) = &error {
+                    let _ = tx.send(msg.clone());
+                }
+                DateTime::<Utc>::from(std::time::SystemTime::UNIX_EPOCH)
+            }
         };
         let filter = json!({
             "dateFilter": {


### PR DESCRIPTION
## Summary
- forward errors from `get_last_sync` via the error channel
- UI already handles `SyncError` messages and displays them

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68665ebcf96c8333b6013629faa5f2bc