### PR TITLE
Forward sync errors to UI

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -553,6 +553,7 @@ impl Application for GooglePiczUI {
                 Some(ts) => format!("Last synced {}", ts.to_rfc3339()),
                 None => "Never synced".to_string(),
             }))
+            .push(text(format!("Errors: {}", self.errors.len())))
             .spacing(20)
             .align_items(iced::Alignment::Center);
 


### PR DESCRIPTION
## Summary
- notify UI if sending progress updates fails
- show error count in UI header

## Testing
- `cargo test --workspace --all-targets --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686665b5a01483338d006e4cdf4f9a87