### PR TITLE
Improve sync error reporting

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -376,6 +376,7 @@ impl Application for GooglePiczUI {
                 }
             },
             Message::SyncError(err_msg) => {
+                tracing::error!("Sync error: {}", err_msg);
                 self.errors.push(err_msg);
                 return GooglePiczUI::error_timeout();
             }


### PR DESCRIPTION
## Summary
- add error logging when forwarding errors in sync module
- log sync errors in UI

## Testing
- `cargo test --all -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_686676d6f6c48333a5354872c6914019