### PR TITLE
Extend CLI overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
   [![Rust](https://img.shields.io/badge/Rust-1.70+-orange?logo=rust)](https://www.rust-lang.org/)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+  [![CI](https://github.com/Christopher-Schulze/GooglePicz/actions/workflows/ci.yml/badge.svg)](https://github.com/Christopher-Schulze/GooglePicz/actions/workflows/ci.yml)
   [![Project Status: WIP](https://img.shields.io/badge/status-WIP-yellow)](https://github.com/Christopher-Schulze/GooglePicz)
 </div>
 
@@ -88,13 +89,15 @@ GooglePicz/
 See the following documents for additional details:
 - [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md) – detailed technical documentation.
 - [Configuration Guide](docs/CONFIGURATION.md) – lists available `AppConfig` options.
+- Command line flags (e.g. `--log-level debug`) can override config values at runtime.
 - [Example Config](docs/EXAMPLE_CONFIG.md) – sample `AppConfig` file.
 - [Release Artifacts Guide](docs/RELEASE_ARTIFACTS.md) – how to create installers.
 
 ## Sync CLI
 
 Run the `sync_cli` binary for manual synchronization or to inspect the local cache.
-Like the GUI, it reads settings from `~/.googlepicz/config` via `AppConfig`.
+Like the GUI, it reads settings from `~/.googlepicz/config` via `AppConfig` and supports
+the same command line overrides (e.g. `--log-level debug`).
 The tool exposes subcommands for `sync`, `status`, `clear-cache`, `list-albums`,
 `create-album`, `delete-album` and `cache-stats` and prints progress updates
 to stdout while downloading items. The source code lives in

--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -21,6 +21,21 @@ mod config;
     about = "GooglePicz synchronization CLI"
 )]
 struct Cli {
+    /// Override log level (e.g. info, debug)
+    #[arg(long)]
+    log_level: Option<String>,
+    /// Override OAuth redirect port
+    #[arg(long)]
+    oauth_redirect_port: Option<u16>,
+    /// Override number of thumbnails to preload
+    #[arg(long)]
+    thumbnails_preload: Option<usize>,
+    /// Override sync interval in minutes
+    #[arg(long)]
+    sync_interval_minutes: Option<u64>,
+    /// Path to config file
+    #[arg(long)]
+    config: Option<PathBuf>,
     #[command(subcommand)]
     command: Commands,
 }
@@ -53,7 +68,13 @@ enum Commands {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    let cfg = config::AppConfig::load();
+    let overrides = config::AppConfigOverrides {
+        log_level: cli.log_level.clone(),
+        oauth_redirect_port: cli.oauth_redirect_port,
+        thumbnails_preload: cli.thumbnails_preload,
+        sync_interval_minutes: cli.sync_interval_minutes,
+    };
+    let cfg = config::AppConfig::load_from(cli.config.clone()).apply_overrides(&overrides);
     let base_dir = home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".googlepicz");

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,3 +11,5 @@ Values can be placed in `~/.googlepicz/config` and are loaded via the [config](h
 | `sync_interval_minutes` | `u64` | `5` | Minutes between automatic synchronization runs. |
 
 Create or edit `~/.googlepicz/config` and provide any of these keys to customize the application.
+
+All settings can also be overridden at runtime using command line options. Run `googlepicz --help` or `sync_cli --help` to see the available flags (e.g. `--log-level debug`).


### PR DESCRIPTION
## Summary
- extend sync_cli with same config overrides as main app
- remove unused helper methods in `AppConfig`
- document overrides in README and config guide

## Testing
- `cargo test`
- `cargo fmt` *(failed: component missing)*

------
https://chatgpt.com/codex/tasks/task_e_68669b2a7f648333aef5d021966f5ceb