### PR TITLE
Fix ImageLoader cache path

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -175,9 +175,9 @@ impl Application for GooglePiczUI {
             None
         };
 
-        let thumbnail_cache_path = home_dir.join(".googlepicz").join("thumbnails");
+        let image_cache_dir = home_dir.join(".googlepicz");
 
-        let image_loader = Arc::new(Mutex::new(ImageLoader::new(thumbnail_cache_path)));
+        let image_loader = Arc::new(Mutex::new(ImageLoader::new(image_cache_dir)));
 
         let progress_receiver = progress_flag.map(|rx| Arc::new(Mutex::new(rx)));
         let error_receiver = error_flag.map(|rx| Arc::new(Mutex::new(rx)));

--- a/ui/tests/image_loader.rs
+++ b/ui/tests/image_loader.rs
@@ -15,7 +15,8 @@ async fn test_thumbnail_cached() {
     let url = format!("{}/img.jpg", server.url(""));
 
     loader.load_thumbnail("1", &url).await.unwrap();
-    assert!(dir.path().join("thumbnails/1.jpg").exists());
+    let thumb_path = dir.path().join("thumbnails").join("1.jpg");
+    assert!(thumb_path.exists());
     mock.assert_hits(1);
 
     // Second call should use cache
@@ -36,7 +37,8 @@ async fn test_full_image_cached() {
     let url = format!("{}/img.jpg", server.url(""));
 
     loader.load_full_image("1", &url).await.unwrap();
-    assert!(dir.path().join("full/1.jpg").exists());
+    let full_path = dir.path().join("full").join("1.jpg");
+    assert!(full_path.exists());
     mock.assert_hits(1);
 
     loader.load_full_image("1", &url).await.unwrap();


### PR DESCRIPTION
## Summary
- initialize `ImageLoader` with `~/.googlepicz` as base directory
- adjust tests for image caching path

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6866f79691b48333a4a60b65246a6b25