### PR TITLE
Improve error banner display

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -558,21 +558,28 @@ impl Application for GooglePiczUI {
             .spacing(20)
             .align_items(iced::Alignment::Center);
 
-        let mut error_column = Column::new().spacing(5);
-        for (i, msg) in self.errors.iter().enumerate() {
-            let row = row![
-                text(msg.clone()).size(16),
-                button("Dismiss").on_press(Message::DismissError(i))
-            ]
-            .spacing(10)
-            .align_items(iced::Alignment::Center);
-            error_column =
-                error_column.push(container(row).style(error_container_style()).padding(10));
-        }
         let error_banner = if self.errors.is_empty() {
             None
         } else {
-            Some(error_column)
+            let mut banner = Column::new().spacing(5);
+            banner = banner.push(
+                row![
+                    text("Operation failed").size(16),
+                    button("Dismiss All").on_press(Message::ClearErrors)
+                ]
+                .spacing(10)
+                .align_items(iced::Alignment::Center),
+            );
+            for (i, msg) in self.errors.iter().enumerate() {
+                let row = row![
+                    text(msg.clone()).size(16),
+                    button("Dismiss").on_press(Message::DismissError(i))
+                ]
+                .spacing(10)
+                .align_items(iced::Alignment::Center);
+                banner = banner.push(row);
+            }
+            Some(container(banner).style(error_container_style()).padding(10).width(Length::Fill))
         };
 
         let album_dialog = if self.creating_album {

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -63,3 +63,15 @@ fn test_dismiss_error() {
     let _ = ui.update(Message::DismissError(0));
     assert_eq!(ui.error_count(), 0);
 }
+
+#[test]
+#[serial]
+fn test_sync_error_added() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0));
+    let _ = ui.update(Message::SyncError("boom".into()));
+    assert!(ui.error_count() > 0);
+}


### PR DESCRIPTION
## Summary
- surface errors using a dismissable banner
- add a test exercising the error handler

## Testing
- `cargo test --workspace --lib --tests --release`
- `cargo test -p ui --release`


------
https://chatgpt.com/codex/tasks/task_e_6866f79b1964833390a22774a85c3392