### PR TITLE
Implement concurrent downloads

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -16,6 +16,7 @@ auth = { path = "../auth" }
 tracing = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
+futures = "0.3"
 
 [dev-dependencies]
 httpmock = "0.6"


### PR DESCRIPTION
## Summary
- limit simultaneous image downloads with a semaphore
- allow `ImageLoader` to preload thumbnails concurrently
- add `futures` crate to `ui`

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_6866fdda45448333bd0d218af0bb4278