### PR TITLE
Implement packaging command availability checks

### DIFF
--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -8,6 +8,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 toml = "0.5"
 thiserror = { workspace = true }
+which = "4"
 
 [dev-dependencies]
 serial_test = "2"


### PR DESCRIPTION
## Summary
- verify external commands exist in the packaging crate
- rename dmg output using workspace version

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_68670bc8ebc083339f0b3c950ac07945