### PR TITLE
Add periodic sync error channel and UI listener

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -178,8 +178,8 @@ impl Syncer {
         self,
         interval: Duration,
         progress_tx: mpsc::UnboundedSender<SyncProgress>,
-        error_tx: mpsc::UnboundedSender<String>,
-    ) -> (JoinHandle<()>, oneshot::Sender<()>) {
+    ) -> (JoinHandle<()>, oneshot::Sender<()>, mpsc::UnboundedReceiver<String>) {
+        let (error_tx, error_rx) = mpsc::unbounded_channel();
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
         let handle = spawn_local(async move {
             let mut syncer = self;
@@ -208,7 +208,7 @@ impl Syncer {
                 }
             }
         });
-        (handle, shutdown_tx)
+        (handle, shutdown_tx, error_rx)
     }
 }
 

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -1,0 +1,33 @@
+use sync::Syncer;
+use serial_test::serial;
+use tempfile::NamedTempFile;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_periodic_sync_reports_error() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_ACCESS_TOKEN", "token");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "refresh");
+    // create syncer with mocked API success
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    let file = NamedTempFile::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut syncer = Syncer::new(file.path()).await.unwrap();
+            // remove API mocking so periodic sync fails when calling the network
+            std::env::remove_var("MOCK_API_CLIENT");
+            let (prog_tx, _prog_rx) = mpsc::unbounded_channel();
+            let (handle, shutdown, mut err_rx) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx);
+            let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
+            assert!(err.is_some());
+            let _ = shutdown.send(());
+            let _ = handle.await;
+        })
+        .await;
+    std::env::remove_var("MOCK_KEYRING");
+    std::env::remove_var("MOCK_ACCESS_TOKEN");
+    std::env::remove_var("MOCK_REFRESH_TOKEN");
+}


### PR DESCRIPTION
## Summary
- expose a dedicated error channel from `start_periodic_sync`
- use the channel from the application entry point
- add regression test for error reporting when periodic sync fails

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6867a643a5908333841d5f702adf1e50