### PR TITLE
Enhance packaging workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,64 +6,36 @@ on:
   pull_request:
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/christopher-schulze/googlepicz-ci:latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Format check
-        run: cargo fmt -- --check
-
-      - name: Clippy check
-        run: cargo clippy -- -D warnings
-
-      - name: Run tests
-        run: cargo test --all
-
-      - name: Build release
-        run: cargo build --release --package googlepicz
-
-      - name: Package
-        run: cargo run --package packaging --bin packager
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: googlepicz-linux
-          path: target/release/googlepicz*
-
-  build-macos:
-    runs-on: macos-latest
+  package:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     env:
       MAC_SIGN_ID: ${{ secrets.MAC_SIGN_ID }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      WINDOWS_CERT: ${{ secrets.WINDOWS_CERT }}
+      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+
       - name: Install Rust toolchain
+        if: runner.os != 'Linux'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
           components: rustfmt, clippy
 
+      - name: Install platform tools
+        if: runner.os == 'Windows'
+        run: choco install nsis -y
+
       - name: Install cargo-bundle
+        if: runner.os == 'macOS'
         run: cargo install cargo-bundle
 
       - name: Cache cargo registry
@@ -92,62 +64,26 @@ jobs:
       - name: Package
         run: cargo run --package packaging --bin packager
 
+      - name: Upload Linux artifact
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: googlepicz-linux
+          path: GooglePicz-*.deb
+
       - name: Upload macOS artifact
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: googlepicz-macos
-          path: target/release/bundle/osx/GooglePicz.app
-
-  build-windows:
-    runs-on: windows-latest
-    env:
-      WINDOWS_CERT: ${{ secrets.WINDOWS_CERT }}
-      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
-      - name: Install NSIS
-        run: choco install nsis -y
-
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Format check
-        run: cargo fmt -- --check
-
-      - name: Clippy check
-        run: cargo clippy -- -D warnings
-
-      - name: Run tests
-        run: cargo test --all
-
-      - name: Build release
-        run: cargo build --release --package googlepicz
-
-      - name: Package
-        run: cargo run --package packaging --bin packager
+          path: target/release/GooglePicz-*.dmg
 
       - name: Upload Windows artifact
+        if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: googlepicz-windows
-          path: GooglePiczSetup.exe
+          path: target/windows/GooglePicz-*-Setup.exe
 
   packaging-tests:
     runs-on: ${{ matrix.os }}

--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -94,6 +94,10 @@ fn create_macos_installer() -> Result<(), PackagingError> {
             "codesign",
             &["--deep", "--force", "-s", &identity, app_path],
         )?;
+        run_command(
+            "codesign",
+            &["--verify", "--deep", "--strict", app_path],
+        )?;
     }
 
     let dmg_path = "target/release/GooglePicz.dmg";
@@ -113,6 +117,7 @@ fn create_macos_installer() -> Result<(), PackagingError> {
     )?;
     if !identity.is_empty() {
         run_command("codesign", &["--force", "-s", &identity, dmg_path])?;
+        run_command("codesign", &["--verify", dmg_path])?;
     }
 
     if let Ok(apple_id) = std::env::var("APPLE_ID") {
@@ -131,6 +136,7 @@ fn create_macos_installer() -> Result<(), PackagingError> {
             ],
         )?;
         run_command("xcrun", &["stapler", "staple", dmg_path])?;
+        run_command("xcrun", &["stapler", "validate", dmg_path])?;
     }
 
     let version = workspace_version()?;
@@ -189,6 +195,7 @@ fn create_windows_installer() -> Result<(), PackagingError> {
                         target,
                     ],
                 )?;
+                run_command("signtool", &["verify", "/pa", target])?;
             }
         }
     }
@@ -236,6 +243,7 @@ fn create_linux_package() -> Result<(), PackagingError> {
         if !key_id.is_empty() {
             let deb_str = deb_path.to_string_lossy();
             run_command("dpkg-sig", &["--sign", "builder", "-k", &key_id, &deb_str])?;
+            run_command("dpkg-sig", &["--verify", &deb_str])?;
         }
     }
 


### PR DESCRIPTION
## Summary
- verify signatures after signing macOS, Windows and Linux artifacts
- rename CI workflow to build installers in a single matrix
- upload versioned artifacts per platform

## Testing
- `cargo test --all`
- `cargo fmt --all` *(fails: component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867a64a827883338ff659d80792b1f5