### PR TITLE
Add tests for auth and cache error scenarios

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -414,4 +414,29 @@ mod tests {
         std::env::remove_var("MOCK_REFRESH_TOKEN");
         std::env::remove_var("MOCK_KEYRING");
     }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_get_access_token_missing() {
+        std::env::set_var("MOCK_KEYRING", "1");
+        {
+            let mut store = MOCK_STORE.lock().unwrap();
+            store.remove("access_token");
+        }
+        let result = get_access_token();
+        assert!(result.is_err());
+        std::env::remove_var("MOCK_KEYRING");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_refresh_access_token_missing_vars() {
+        std::env::set_var("MOCK_KEYRING", "1");
+        std::env::remove_var("MOCK_REFRESH_TOKEN");
+        std::env::remove_var("GOOGLE_CLIENT_ID");
+        std::env::remove_var("GOOGLE_CLIENT_SECRET");
+        let result = refresh_access_token().await;
+        assert!(result.is_err());
+        std::env::remove_var("MOCK_KEYRING");
+    }
 }

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -660,5 +660,22 @@ mod tests {
             .unwrap();
         assert_eq!(ts, "1970-01-01T00:00:00Z");
     }
+
+    #[test]
+    fn test_cache_manager_new_invalid_path() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let result = CacheManager::new(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_insert_media_item_invalid_metadata() {
+        let tmp = NamedTempFile::new().expect("create temp file");
+        let cache = CacheManager::new(tmp.path()).expect("create cache manager");
+        let mut item = sample_media_item("1");
+        item.media_metadata.width = "not_a_number".into();
+        let result = cache.insert_media_item(&item);
+        assert!(matches!(result, Err(CacheError::SerializationError(_))));
+    }
 }
 

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -259,4 +259,16 @@ mod tests {
         std::env::remove_var("MOCK_REFRESH_TOKEN");
         std::env::remove_var("MOCK_API_CLIENT");
     }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_syncer_new_invalid_db_path() {
+        std::env::set_var("MOCK_KEYRING", "1");
+        std::env::set_var("MOCK_REFRESH_TOKEN", "token");
+        let dir = tempfile::tempdir().expect("create dir");
+        let result = Syncer::new(dir.path()).await;
+        assert!(result.is_err());
+        std::env::remove_var("MOCK_REFRESH_TOKEN");
+        std::env::remove_var("MOCK_KEYRING");
+    }
 }


### PR DESCRIPTION
## Summary
- add test for missing token errors in `auth`
- test error cases in cache manager and syncer

## Testing
- `cargo test --all --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_6867a648b8788333b16a7b5c42fd7d2f