### PR TITLE
Report sync failures via channel

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -178,8 +178,8 @@ impl Syncer {
         self,
         interval: Duration,
         progress_tx: mpsc::UnboundedSender<SyncProgress>,
-    ) -> (JoinHandle<()>, oneshot::Sender<()>, mpsc::UnboundedReceiver<String>) {
-        let (error_tx, error_rx) = mpsc::unbounded_channel();
+        error_tx: mpsc::UnboundedSender<String>,
+    ) -> (JoinHandle<()>, oneshot::Sender<()>) {
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
         let handle = spawn_local(async move {
             let mut syncer = self;
@@ -208,7 +208,7 @@ impl Syncer {
                 }
             }
         });
-        (handle, shutdown_tx, error_rx)
+        (handle, shutdown_tx)
     }
 }
 

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -20,7 +20,8 @@ async fn test_periodic_sync_reports_error() {
             // remove API mocking so periodic sync fails when calling the network
             std::env::remove_var("MOCK_API_CLIENT");
             let (prog_tx, _prog_rx) = mpsc::unbounded_channel();
-            let (handle, shutdown, mut err_rx) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx);
+            let (err_tx, mut err_rx) = mpsc::unbounded_channel();
+            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx);
             let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
             assert!(err.is_some());
             let _ = shutdown.send(());

--- a/sync/tests/sync_media_items_error.rs
+++ b/sync/tests/sync_media_items_error.rs
@@ -1,0 +1,31 @@
+use sync::Syncer;
+use serial_test::serial;
+use tempfile::NamedTempFile;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_sync_media_items_reports_error() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_ACCESS_TOKEN", "token");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "refresh");
+    // build syncer with mocked API for initialization
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    let file = NamedTempFile::new().unwrap();
+    let mut syncer = Syncer::new(file.path()).await.unwrap();
+    // drop mock so sync_media_items fails when calling API
+    std::env::remove_var("MOCK_API_CLIENT");
+    let (prog_tx, _prog_rx) = mpsc::unbounded_channel();
+    let (err_tx, mut err_rx) = mpsc::unbounded_channel();
+    let result = syncer
+        .sync_media_items(Some(prog_tx), Some(err_tx))
+        .await;
+    assert!(result.is_err());
+    // ensure error forwarded
+    let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
+    assert!(err.is_some());
+    std::env::remove_var("MOCK_KEYRING");
+    std::env::remove_var("MOCK_ACCESS_TOKEN");
+    std::env::remove_var("MOCK_REFRESH_TOKEN");
+}


### PR DESCRIPTION
## Summary
- allow providing an error channel to `start_periodic_sync`
- forward periodic sync errors using the provided sender
- wire new sender in the application
- test forwarding from `sync_media_items`

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6867b9d29a0c8333ad9f299598a698b0