### PR TITLE
Document debug console option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Having trouble starting the application? Here are a few common issues:
 - **OAuth redirect fails** – Check that the redirect port in your config is open and not blocked by a firewall.
 - **Packaging errors** – The packager relies on external tools like `cargo deb` and `makensis`. Use the `MOCK_COMMANDS` environment variable to run packaging tests without these tools.
 - **Developing without network access** – Set `MOCK_API_CLIENT=1` and `MOCK_KEYRING=1` to enable offline mode while testing.
+- **Need more insight into async tasks?** – Set `debug_console = true` in `~/.googlepicz/config` or pass `--debug-console` to print detailed Tokio diagnostics.
 
 ## 🏗️ Project Structure
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,7 +9,8 @@ Values can be placed in `~/.googlepicz/config` and are loaded via the [config](h
 | `oauth_redirect_port` | `u16` | `8080` | Port used for OAuth redirect during authentication. |
 | `thumbnails_preload` | `usize` | `20` | Number of thumbnails to preload when displaying an album. |
 | `sync_interval_minutes` | `u64` | `5` | Minutes between automatic synchronization runs. |
+| `debug_console` | `bool` | `false` | Enable the tokio console subscriber for debugging asynchronous tasks. |
 
-Create or edit `~/.googlepicz/config` and provide any of these keys to customize the application.
+Create or edit `~/.googlepicz/config` and provide any of these keys to customize the application. Setting `debug_console = true` turns on Tokio's debugging console.
 
-All settings can also be overridden at runtime using command line options. Run `googlepicz --help` or `sync_cli --help` to see the available flags (e.g. `--log-level debug`).
+All settings can also be overridden at runtime using command line options. Run `googlepicz --help` or `sync_cli --help` to see the available flags. The `debug_console` option can be enabled with the `--debug-console` flag.

--- a/docs/EXAMPLE_CONFIG.md
+++ b/docs/EXAMPLE_CONFIG.md
@@ -7,6 +7,7 @@ log_level = "debug"
 oauth_redirect_port = 9000
 thumbnails_preload = 30
 sync_interval_minutes = 15
+debug_console = false
 ```
 
 Adjust the values as needed.


### PR DESCRIPTION
## Summary
- document `debug_console` option in the configuration guide
- show the option in the example config
- mention how to enable the debug console in README troubleshooting

## Testing
- `cargo check --all`
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_6867b9d26f7083339ec98956a4818598