### PR TITLE
Add tracing spans and profiling docs

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -174,6 +174,30 @@ cargo run --package googlepicz --bin sync_cli -- cache-stats
 
 Displays the number of cached albums and media items.
 
+## 📈 Performance Profiling
+
+Enable detailed tracing spans and Tokio's console to diagnose slow operations.
+Install the console viewer:
+
+```bash
+cargo install tokio-console
+```
+
+Run it in a separate terminal:
+
+```bash
+tokio-console
+```
+
+Launch the application with the profiling features enabled:
+
+```bash
+cargo run --package googlepicz --features sync/trace-spans,ui/trace-spans -- --debug-console
+```
+
+The console will display asynchronous task metrics while span timings are
+written to `~/.googlepicz/googlepicz.log`.
+
 ## 🐳 CI Docker Image
 
 The repository includes a `Dockerfile.ci` used to build a container image with stable Rust and the packaging tools required for CI. To build and publish the image:

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -16,3 +16,6 @@ thiserror = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 serial_test = "2"
+
+[features]
+trace-spans = []

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -35,6 +35,7 @@ pub enum SyncProgress {
 }
 
 impl Syncer {
+    #[cfg_attr(feature = "trace-spans", tracing::instrument)]
     pub async fn new(db_path: &Path) -> Result<Self, SyncError> {
         let access_token = ensure_access_token_valid().await.map_err(|e| {
             SyncError::AuthenticationError(format!("Failed to get access token: {}", e))
@@ -51,6 +52,7 @@ impl Syncer {
         })
     }
 
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self, progress, error)))]
     pub async fn sync_media_items(
         &mut self,
         progress: Option<mpsc::UnboundedSender<SyncProgress>>,
@@ -178,6 +180,7 @@ impl Syncer {
         Ok(())
     }
 
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self, progress_tx, error_tx)))]
     pub fn start_periodic_sync(
         self,
         interval: Duration,

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -23,3 +23,6 @@ httpmock = "0.6"
 tempfile = "3"
 serial_test = "2"
 
+[features]
+trace-spans = []
+

--- a/ui/src/image_loader.rs
+++ b/ui/src/image_loader.rs
@@ -36,6 +36,7 @@ impl ImageLoader {
         }
     }
 
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self)))]
     pub async fn load_thumbnail(
         &self,
         media_id: &str,
@@ -88,6 +89,7 @@ impl ImageLoader {
         Ok(handle)
     }
 
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self)))]
     pub async fn load_full_image(
         &self,
         media_id: &str,
@@ -136,6 +138,7 @@ impl ImageLoader {
     }
 
     #[allow(dead_code)]
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self, media_items)))]
     pub async fn preload_thumbnails(&self, media_items: &[api_client::MediaItem], count: usize) {
         let start = Instant::now();
         let stream = futures::stream::iter(media_items.iter().take(count));

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -39,6 +39,7 @@ fn error_container_style() -> iced::theme::Container {
     }))
 }
 
+#[cfg_attr(feature = "trace-spans", tracing::instrument(skip(progress, errors)))]
 pub fn run(
     progress: Option<mpsc::UnboundedReceiver<SyncProgress>>,
     errors: Option<mpsc::UnboundedReceiver<String>>,
@@ -154,6 +155,7 @@ impl Application for GooglePiczUI {
         usize,
     );
 
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(flags)))]
     fn new(flags: Self::Flags) -> (Self, Command<Message>) {
         let (progress_flag, error_flag, preload_count) = flags;
         let mut init_errors = Vec::new();
@@ -217,6 +219,7 @@ impl Application for GooglePiczUI {
         String::from("GooglePicz - Google Photos Manager")
     }
 
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self)))]
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::LoadPhotos => {
@@ -524,6 +527,7 @@ impl Application for GooglePiczUI {
         Command::none()
     }
 
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self)))]
     fn subscription(&self) -> Subscription<Message> {
         let mut subs: Vec<Subscription<Message>> = Vec::new();
 
@@ -556,6 +560,7 @@ impl Application for GooglePiczUI {
         Subscription::batch(subs)
     }
 
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self)))]
     fn view(&self) -> Element<Message> {
         let mut header = row![
             text("GooglePicz").size(24),


### PR DESCRIPTION
## Summary
- gate tracing spans behind `trace-spans` in sync and ui crates
- instrument major sync and ui operations with optional spans
- document how to profile using `tokio-console`

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6867c30abca88333af6b88454945960a