### PR TITLE
Add configurable cache path

### DIFF
--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -2,7 +2,6 @@ use cache::CacheManager;
 use clap::{Parser, Subcommand};
 use api_client::ApiClient;
 use auth::ensure_access_token_valid;
-use dirs::home_dir;
 use std::path::PathBuf;
 use sync::{SyncProgress, Syncer};
 use tokio::sync::mpsc;
@@ -79,9 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         debug_console: cli.debug_console,
     };
     let cfg = config::AppConfig::load_from(cli.config.clone()).apply_overrides(&overrides);
-    let base_dir = home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".googlepicz");
+    let base_dir = cfg.cache_path.clone();
     std::fs::create_dir_all(&base_dir)?;
     let file_appender = rolling::daily(&base_dir, "googlepicz.log");
     let (file_writer, _guard) = tracing_appender::non_blocking(file_appender);

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -9,6 +9,7 @@ pub struct AppConfig {
     #[allow(dead_code)]
     pub sync_interval_minutes: u64,
     pub debug_console: bool,
+    pub cache_path: PathBuf,
 }
 
 pub struct AppConfigOverrides {
@@ -39,6 +40,14 @@ impl AppConfig {
         let thumbnails_preload = cfg.get_int("thumbnails_preload").unwrap_or(20) as usize;
         let sync_interval_minutes = cfg.get_int("sync_interval_minutes").unwrap_or(5) as u64;
         let debug_console = cfg.get_bool("debug_console").unwrap_or(false);
+        let cache_path = cfg
+            .get_string("cache_path")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                dirs::home_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join(".googlepicz")
+            });
 
         Self {
             log_level,
@@ -46,6 +55,7 @@ impl AppConfig {
             thumbnails_preload,
             sync_interval_minutes,
             debug_console,
+            cache_path,
         }
     }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -50,9 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         debug_console: cli.debug_console,
     };
     let cfg = config::AppConfig::load_from(cli.config.clone()).apply_overrides(&overrides);
-    let log_dir = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".googlepicz");
+    let log_dir = cfg.cache_path.clone();
     std::fs::create_dir_all(&log_dir)?;
     let file_appender = rolling::daily(&log_dir, "googlepicz.log");
     let (file_writer, _guard) = tracing_appender::non_blocking(file_appender);
@@ -89,9 +87,7 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
     }
 
     // Setup cache directory
-    let cache_dir = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".googlepicz");
+    let cache_dir = cfg.cache_path.clone();
 
     let db_path = cache_dir.join("cache.sqlite");
 
@@ -157,8 +153,9 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
                 syncer.start_periodic_sync(interval, tx, err_tx)
             };
 
+            let cache_dir = cfg.cache_path.clone();
             let ui_thread = std::thread::spawn(move || {
-                if let Err(e) = ui::run(Some(rx), Some(err_rx), preload) {
+                if let Err(e) = ui::run(Some(rx), Some(err_rx), preload, cache_dir) {
                     error!("UI error: {}", e);
                 }
             });
@@ -172,7 +169,7 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
         Err(e) => {
             error!("❌ Failed to initialize syncer: {}", e);
             error!("💡 The UI will still start, but photos may not be available until sync is working.");
-            ui::run(None, None, cfg.thumbnails_preload)?;
+            ui::run(None, None, cfg.thumbnails_preload, cfg.cache_path.clone())?;
         }
     }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,6 +9,7 @@ Values can be placed in `~/.googlepicz/config` and are loaded via the [config](h
 | `oauth_redirect_port` | `u16` | `8080` | Port used for OAuth redirect during authentication. |
 | `thumbnails_preload` | `usize` | `20` | Number of thumbnails to preload when displaying an album. |
 | `sync_interval_minutes` | `u64` | `5` | Minutes between automatic synchronization runs. |
+| `cache_path` | `String` | `"~/.googlepicz"` | Directory where cache and logs are stored. |
 | `debug_console` | `bool` | `false` | Enable the tokio console subscriber for debugging asynchronous tasks. |
 
 Create or edit `~/.googlepicz/config` and provide any of these keys to customize the application. Setting `debug_console = true` turns on Tokio's debugging console.

--- a/docs/EXAMPLE_CONFIG.md
+++ b/docs/EXAMPLE_CONFIG.md
@@ -7,6 +7,7 @@ log_level = "debug"
 oauth_redirect_port = 9000
 thumbnails_preload = 30
 sync_interval_minutes = 15
+cache_path = "/tmp/googlepicz"
 debug_console = false
 ```
 

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -27,7 +27,7 @@ fn test_initial_state() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (ui, _) = GooglePiczUI::new((None, None, 0));
+    let (ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
     assert_eq!(ui.photo_count(), 0);
     assert_eq!(ui.album_count(), 0);
     assert_eq!(ui.state_debug(), "Grid");
@@ -40,7 +40,7 @@ fn test_select_and_close_photo() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
     let item = sample_item();
 
     let _ = ui.update(Message::SelectPhoto(item.clone()));
@@ -57,7 +57,7 @@ fn test_dismiss_error() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SyncError("err".into()));
     assert_eq!(ui.error_count(), 1);
     let _ = ui.update(Message::DismissError(0));
@@ -71,7 +71,7 @@ fn test_sync_error_added() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SyncError("boom".into()));
     assert!(ui.error_count() > 0);
 }


### PR DESCRIPTION
## Summary
- add `cache_path` option to config
- use cache path in main application, UI, and sync CLI
- update docs and example configuration with the new option

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6867c308466083338887cc29db35b5ec