### PR TITLE
Improve packaging error handling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,10 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo install cargo-bundle
 
+      - name: Install cargo-deb
+        if: runner.os == 'Linux'
+        run: cargo install cargo-deb
+
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ Signing requires a few environment variables:
 - `WINDOWS_CERT` and `WINDOWS_CERT_PASSWORD` – code signing certificate for Windows.
 - `LINUX_SIGN_KEY` – GPG key ID used by `dpkg-sig` to sign the generated `.deb` (optional).
 
+The packager also requires a few external tools to be available in your `PATH`:
+
+- `cargo-deb` – creates Debian packages (`cargo install cargo-deb`)
+- `cargo-bundle` – bundles macOS apps (`cargo install cargo-bundle`)
+- `cargo-bundle-licenses` – collects license metadata (`cargo install cargo-bundle-licenses`)
+- `makensis` – part of the NSIS suite used for Windows installers
+
 Set these variables in your shell or CI environment before running `cargo run --package packaging --bin packager`.
 
 ## Running Tests

--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -33,8 +33,41 @@ fn run_command(cmd: &str, args: &[&str]) -> Result<(), PackagingError> {
         return Ok(());
     }
 
+    if cmd == "cargo" {
+        if let Some(sub) = args.first() {
+            match *sub {
+                "deb" => {
+                    if !command_available("cargo-deb") {
+                        return Err(PackagingError::MissingCommand(
+                            "cargo-deb (install with `cargo install cargo-deb`)".into(),
+                        ));
+                    }
+                }
+                "bundle" => {
+                    if !command_available("cargo-bundle") {
+                        return Err(PackagingError::MissingCommand(
+                            "cargo-bundle (install with `cargo install cargo-bundle`)".into(),
+                        ));
+                    }
+                }
+                "bundle-licenses" => {
+                    if !command_available("cargo-bundle-licenses") {
+                        return Err(PackagingError::MissingCommand(
+                            "cargo-bundle-licenses (install with `cargo install cargo-bundle-licenses`)".into(),
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     if !command_available(cmd) {
-        return Err(PackagingError::MissingCommand(cmd.to_string()));
+        let msg = match cmd {
+            "makensis" => "makensis (install NSIS)".to_string(),
+            _ => cmd.to_string(),
+        };
+        return Err(PackagingError::MissingCommand(msg));
     }
 
     let output = Command::new(cmd)


### PR DESCRIPTION
## Summary
- check for common cargo subcommands in packaging `run_command`
- give more helpful error messages when commands like `makensis` are missing
- list required external tools in README
- install `cargo-deb` during CI on Linux

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867c307f7888333988bc0aade624530