### PR TITLE
Improve sync progress reporting

### DIFF
--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -100,6 +100,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tokio::spawn(async move {
                 while let Some(p) = rx.recv().await {
                     match p {
+                        SyncProgress::Started => println!("Sync started"),
+                        SyncProgress::Retrying(wait) => println!("Retrying in {}s", wait),
                         SyncProgress::ItemSynced(n) => println!("Synced {} items...", n),
                         SyncProgress::Finished(total) => println!("Finished sync: {} items", total),
                     }

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -30,7 +30,9 @@ pub struct Syncer {
 
 #[derive(Debug, Clone)]
 pub enum SyncProgress {
+    Started,
     ItemSynced(u64),
+    Retrying(u64),
     Finished(u64),
 }
 
@@ -57,6 +59,13 @@ impl Syncer {
         error: Option<mpsc::UnboundedSender<String>>,
     ) -> Result<(), SyncError> {
         tracing::info!("Starting media item synchronization...");
+        if let Some(tx) = &progress {
+            if let Err(e) = tx.send(SyncProgress::Started) {
+                if let Some(err_tx) = &error {
+                    let _ = err_tx.send(format!("Failed to send progress: {}", e));
+                }
+            }
+        }
         let mut page_token: Option<String> = None;
         let mut total_synced = 0;
 
@@ -203,6 +212,7 @@ impl Syncer {
                             let _ = error_tx.send(msg.clone());
                             let wait = backoff.min(300);
                             backoff = (backoff * 2).min(300);
+                            let _ = progress_tx.send(SyncProgress::Retrying(wait));
                             sleep(Duration::from_secs(wait)).await;
                         } else {
                             backoff = 1;

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -1,4 +1,4 @@
-use sync::Syncer;
+use sync::{Syncer, SyncProgress};
 use serial_test::serial;
 use tempfile::NamedTempFile;
 use tokio::sync::mpsc;
@@ -19,9 +19,13 @@ async fn test_periodic_sync_reports_error() {
             let mut syncer = Syncer::new(file.path()).await.unwrap();
             // remove API mocking so periodic sync fails when calling the network
             std::env::remove_var("MOCK_API_CLIENT");
-            let (prog_tx, _prog_rx) = mpsc::unbounded_channel();
+            let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel();
             let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx);
+            let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
+            assert!(matches!(start, Some(SyncProgress::Started)));
+            let retry = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
+            assert!(matches!(retry, Some(SyncProgress::Retrying(_))));
             let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
             assert!(err.is_some());
             let _ = shutdown.send(());

--- a/sync/tests/sync_flow.rs
+++ b/sync/tests/sync_flow.rs
@@ -1,4 +1,4 @@
-use sync::Syncer;
+use sync::{Syncer, SyncProgress};
 use cache::CacheManager;
 use serial_test::serial;
 use tempfile::NamedTempFile;
@@ -15,7 +15,10 @@ async fn test_sync_flow_mock() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut syncer = Syncer::new(file.path()).await.unwrap();
     syncer.sync_media_items(Some(tx), None).await.unwrap();
-    assert!(rx.recv().await.is_some());
+    match rx.recv().await {
+        Some(sync::SyncProgress::Started) => {}
+        other => panic!("expected Started progress, got {:?}", other),
+    }
     let cache = CacheManager::new(file.path()).unwrap();
     let items = cache.get_all_media_items().unwrap();
     assert!(!items.is_empty());

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -107,6 +107,7 @@ pub struct GooglePiczUI {
     synced: u64,
     syncing: bool,
     last_synced: Option<DateTime<Utc>>,
+    sync_status: String,
     state: ViewState,
     selected_album: Option<String>,
     errors: Vec<String>,
@@ -182,6 +183,11 @@ impl Application for GooglePiczUI {
         let progress_receiver = progress_flag.map(|rx| Arc::new(Mutex::new(rx)));
         let error_receiver = error_flag.map(|rx| Arc::new(Mutex::new(rx)));
 
+        let status = match last_synced {
+            Some(ts) => format!("Last synced {}", ts.to_rfc3339()),
+            None => "Never synced".to_string(),
+        };
+
         let app = Self {
             photos: Vec::new(),
             albums: Vec::new(),
@@ -195,6 +201,7 @@ impl Application for GooglePiczUI {
             synced: 0,
             syncing: false,
             last_synced,
+            sync_status: status,
             state: ViewState::Grid,
             selected_album: None,
             errors: init_errors,
@@ -371,14 +378,25 @@ impl Application for GooglePiczUI {
                 self.state = ViewState::Grid;
             }
             Message::SyncProgress(progress) => match progress {
+                SyncProgress::Started => {
+                    self.synced = 0;
+                    self.syncing = true;
+                    self.sync_status = "Sync started".into();
+                }
+                SyncProgress::Retrying(wait) => {
+                    self.syncing = false;
+                    self.sync_status = format!("Retrying in {}s", wait);
+                }
                 SyncProgress::ItemSynced(count) => {
                     self.synced = count;
                     self.syncing = true;
+                    self.sync_status = format!("Syncing {} items", count);
                 }
                 SyncProgress::Finished(total) => {
                     self.synced = total;
                     self.syncing = false;
                     self.last_synced = Some(Utc::now());
+                    self.sync_status = format!("Sync completed: {} items", total);
                 }
             },
             Message::SyncError(err_msg) => {
@@ -570,11 +588,7 @@ impl Application for GooglePiczUI {
         }
 
         header = header
-            .push(text(if self.syncing {
-                format!("Syncing {} items...", self.synced)
-            } else {
-                format!("Synced {} items", self.synced)
-            }))
+            .push(text(self.sync_status.clone()))
             .push(text(match self.last_synced {
                 Some(ts) => format!("Last synced {}", ts.to_rfc3339()),
                 None => "Never synced".to_string(),


### PR DESCRIPTION
## Summary
- send `Started` and `Retrying` states through sync progress channel
- show sync state in the UI and display retry messages
- print new progress states in the CLI
- test error forwarding with new progress states

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6867c305d458833398ed98acd638ff41