### PR TITLE
Schedule automatic token refresh

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -150,12 +150,15 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
             }
 
             let (err_tx, err_rx) = tokio::sync::mpsc::unbounded_channel();
-            let (handle, shutdown) = if ensure_access_token_valid().await.is_ok() {
-                syncer.start_periodic_sync(interval, tx, err_tx)
+            let (sync_handle, sync_shutdown) = if ensure_access_token_valid().await.is_ok() {
+                syncer.start_periodic_sync(interval, tx, err_tx.clone())
             } else {
                 error!("❌ Cannot start periodic sync without a valid token");
-                syncer.start_periodic_sync(interval, tx, err_tx)
+                syncer.start_periodic_sync(interval, tx, err_tx.clone())
             };
+
+            let (refresh_handle, refresh_shutdown) =
+                Syncer::start_token_refresh_task(Duration::from_secs(60), err_tx.clone());
 
             let ui_thread = std::thread::spawn(move || {
                 if let Err(e) = ui::run(Some(rx), Some(err_rx), preload) {
@@ -166,8 +169,10 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
             if let Err(e) = ui_thread.join() {
                 error!("UI thread panicked: {:?}", e);
             }
-            let _ = shutdown.send(());
-            let _ = handle.await;
+            let _ = sync_shutdown.send(());
+            let _ = refresh_shutdown.send(());
+            let _ = sync_handle.await;
+            let _ = refresh_handle.await;
         }
         Err(e) => {
             error!("❌ Failed to initialize syncer: {}", e);

--- a/sync/tests/token_refresh_task.rs
+++ b/sync/tests/token_refresh_task.rs
@@ -1,0 +1,24 @@
+use sync::Syncer;
+use serial_test::serial;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_token_refresh_task_reports_error() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    // No refresh token so refresh will fail
+    let (err_tx, mut err_rx) = mpsc::unbounded_channel();
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (handle, shutdown) =
+                Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx);
+            let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
+            assert!(err.is_some());
+            let _ = shutdown.send(());
+            let _ = handle.await;
+        })
+        .await;
+    std::env::remove_var("MOCK_KEYRING");
+}


### PR DESCRIPTION
## Summary
- refresh tokens 5 minutes early and schedule refresh background task
- surface refresh failures via new background task handler
- test token expiration scenarios
- periodically refresh token in app startup

## Testing
- `cargo test --workspace --tests --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6867c3040bf8833391f031ff558b6043