### PR TITLE
Use structured task errors for sync

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3,7 +3,7 @@
 use auth::{authenticate, ensure_access_token_valid};
 use clap::Parser;
 use std::path::PathBuf;
-use sync::Syncer;
+use sync::{Syncer, SyncTaskError};
 use tokio::fs;
 use tokio::task::LocalSet;
 use tokio::time::Duration;
@@ -145,7 +145,7 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
                 error!("❌ Cannot synchronize without a valid access token");
             }
 
-            let (err_tx, err_rx) = tokio::sync::mpsc::unbounded_channel();
+            let (err_tx, err_rx) = tokio::sync::mpsc::unbounded_channel::<SyncTaskError>();
             let (sync_handle, sync_shutdown) = if ensure_access_token_valid().await.is_ok() {
                 syncer.start_periodic_sync(interval, tx, err_tx.clone())
             } else {

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -1,4 +1,4 @@
-use sync::{Syncer, SyncProgress};
+use sync::{Syncer, SyncProgress, SyncTaskError};
 use serial_test::serial;
 use tempfile::NamedTempFile;
 use tokio::sync::mpsc;
@@ -20,7 +20,7 @@ async fn test_periodic_sync_reports_error() {
             // remove API mocking so periodic sync fails when calling the network
             std::env::remove_var("MOCK_API_CLIENT");
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
-            let (err_tx, mut err_rx) = mpsc::unbounded_channel();
+            let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
             let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx);
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));

--- a/sync/tests/sync_media_items_error.rs
+++ b/sync/tests/sync_media_items_error.rs
@@ -1,4 +1,4 @@
-use sync::{Syncer, SyncProgress};
+use sync::{Syncer, SyncProgress, SyncTaskError};
 use serial_test::serial;
 use tempfile::NamedTempFile;
 use tokio::sync::mpsc;
@@ -17,7 +17,7 @@ async fn test_sync_media_items_reports_error() {
     // drop mock so sync_media_items fails when calling API
     std::env::remove_var("MOCK_API_CLIENT");
     let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
-    let (err_tx, mut err_rx) = mpsc::unbounded_channel();
+    let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
     let result = syncer
         .sync_media_items(Some(prog_tx), Some(err_tx))
         .await;

--- a/sync/tests/token_refresh_task.rs
+++ b/sync/tests/token_refresh_task.rs
@@ -1,4 +1,4 @@
-use sync::Syncer;
+use sync::{Syncer, SyncTaskError};
 use serial_test::serial;
 use tokio::sync::mpsc;
 use tokio::time::{timeout, Duration};
@@ -8,7 +8,7 @@ use tokio::time::{timeout, Duration};
 async fn test_token_refresh_task_reports_error() {
     std::env::set_var("MOCK_KEYRING", "1");
     // No refresh token so refresh will fail
-    let (err_tx, mut err_rx) = mpsc::unbounded_channel();
+    let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -1,4 +1,5 @@
 use ui::{GooglePiczUI, Message};
+use sync::SyncTaskError;
 use iced::Application;
 use tempfile::tempdir;
 use api_client::{MediaItem, MediaMetadata};
@@ -58,7 +59,7 @@ fn test_dismiss_error() {
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
     let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
-    let _ = ui.update(Message::SyncError("err".into()));
+    let _ = ui.update(Message::SyncError(SyncTaskError::Other("err".into())));
     assert_eq!(ui.error_count(), 1);
     let _ = ui.update(Message::DismissError(0));
     assert_eq!(ui.error_count(), 0);
@@ -72,6 +73,6 @@ fn test_sync_error_added() {
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
     let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
-    let _ = ui.update(Message::SyncError("boom".into()));
+    let _ = ui.update(Message::SyncError(SyncTaskError::Other("boom".into())));
     assert!(ui.error_count() > 0);
 }


### PR DESCRIPTION
## Summary
- add `SyncTaskError` for periodic sync and token refresh tasks
- propagate `SyncTaskError` through channels
- update application and UI to work with the new error type
- adjust tests for the structured error

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68681a769b04833381e58a8f1fd937f8