### PR TITLE
Add artifact name verification

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Package
         run: cargo run --package packaging --bin packager
 
+      - name: Verify metadata and artifacts
+        run: cargo run --package packaging --bin ci_checks
+
       - name: Upload Linux artifact
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4

--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -9,6 +9,7 @@ tracing = { workspace = true }
 toml = "0.5"
 thiserror = { workspace = true }
 which = "4"
+serde_json = "1"
 
 [dev-dependencies]
 serial_test = "2"

--- a/packaging/src/bin/ci_checks.rs
+++ b/packaging/src/bin/ci_checks.rs
@@ -1,0 +1,6 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    packaging::utils::verify_metadata_package_name("googlepicz")?;
+    packaging::utils::verify_artifact_names()?;
+    println!("CI checks passed");
+    Ok(())
+}

--- a/packaging/src/utils.rs
+++ b/packaging/src/utils.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 
 use toml::Value;
+use serde_json::Value as JsonValue;
 
 use crate::PackagingError;
 
@@ -38,4 +40,53 @@ pub fn workspace_version() -> Result<String, PackagingError> {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
         .ok_or_else(|| PackagingError::Other("workspace.package.version not found".into()))
+}
+
+/// Verify that `cargo metadata` lists the expected package name.
+pub fn verify_metadata_package_name(expected: &str) -> Result<(), PackagingError> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .output()
+        .map_err(|e| PackagingError::Other(format!("Failed to run cargo metadata: {}", e)))?;
+    if !output.status.success() {
+        return Err(PackagingError::Other("cargo metadata failed".into()));
+    }
+    let metadata: JsonValue = serde_json::from_slice(&output.stdout)
+        .map_err(|e| PackagingError::Other(format!("Failed to parse cargo metadata: {}", e)))?;
+    let packages = metadata
+        .get("packages")
+        .and_then(|p| p.as_array())
+        .ok_or_else(|| PackagingError::Other("No packages field in metadata".into()))?;
+
+    let found = packages.iter().any(|pkg| pkg.get("name").and_then(|n| n.as_str()) == Some(expected));
+    if found {
+        Ok(())
+    } else {
+        Err(PackagingError::Other(format!("Package '{}' not found", expected)))
+    }
+}
+
+/// Check that the built installer artifacts include the workspace version in their name.
+pub fn verify_artifact_names() -> Result<(), PackagingError> {
+    let root = get_project_root();
+    let version = workspace_version()?;
+
+    if cfg!(target_os = "linux") {
+        let path = root.join(format!("GooglePicz-{}.deb", version));
+        if !path.exists() {
+            return Err(PackagingError::Other(format!("Missing artifact: {:?}", path)));
+        }
+    } else if cfg!(target_os = "macos") {
+        let path = root.join(format!("target/release/GooglePicz-{}.dmg", version));
+        if !path.exists() {
+            return Err(PackagingError::Other(format!("Missing artifact: {:?}", path)));
+        }
+    } else if cfg!(target_os = "windows") {
+        let path = root.join(format!("target/windows/GooglePicz-{}-Setup.exe", version));
+        if !path.exists() {
+            return Err(PackagingError::Other(format!("Missing artifact: {:?}", path)));
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- check that build artifacts include the workspace version
- verify the root package name via `cargo metadata`
- add a small CI helper script
- use the helper in the Rust workflow

## Testing
- `cargo test -p packaging`
- `cargo build -p packaging`

------
https://chatgpt.com/codex/tasks/task_e_68683d346f40833396616e86f7107dbd