### PR TITLE
Add tool table for release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,13 @@ Signing requires a few environment variables:
 - `WINDOWS_CERT` and `WINDOWS_CERT_PASSWORD` – code signing certificate for Windows.
 - `LINUX_SIGN_KEY` – GPG key ID used by `dpkg-sig` to sign the generated `.deb` (optional).
 
-The packager also requires a few external tools to be available in your `PATH`:
+The packager also requires a few external tools to be available in your `PATH`.
+See the [required tools table](docs/RELEASE_ARTIFACTS.md#required-tools) for
+installation commands.
 
-- `cargo-deb` – creates Debian packages (`cargo install cargo-deb`)
-- `cargo-bundle` – bundles macOS apps (`cargo install cargo-bundle`)
-- `cargo-bundle-licenses` – collects license metadata (`cargo install cargo-bundle-licenses`)
+- `cargo-deb` – creates Debian packages
+- `cargo-bundle` – bundles macOS apps
+- `cargo-bundle-licenses` – collects license metadata
 - `makensis` – part of the NSIS suite used for Windows installers
 
 Set these variables in your shell or CI environment before running `cargo run --package packaging --bin packager`.

--- a/docs/RELEASE_ARTIFACTS.md
+++ b/docs/RELEASE_ARTIFACTS.md
@@ -5,8 +5,16 @@ This document describes how to build installers for all supported platforms.
 ## Prerequisites
 
 - Rust toolchain installed (`rustup`)
-- `cargo-deb` for creating Debian packages (`cargo install cargo-deb`)
 - Required signing credentials if you want signed binaries
+
+### Required Tools {#required-tools}
+
+| Tool | Purpose | Installation |
+| --- | --- | --- |
+| `cargo-deb` | Build Debian packages | `cargo install cargo-deb` |
+| `cargo-bundle` | Bundle macOS apps | `cargo install cargo-bundle` |
+| `cargo-bundle-licenses` | Collect license metadata | `cargo install cargo-bundle-licenses` |
+| `makensis` | Create Windows installers | Install the [NSIS](https://nsis.sourceforge.io/) package |
 
 Environment variables:
 


### PR DESCRIPTION
## Summary
- document required packaging tools in `RELEASE_ARTIFACTS.md`
- mention the new table from the README

## Testing
- `cargo test` *(fails: test_new_applies_migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68683d2e824883339ffdc456b628c046