### PR TITLE
Add runtime file-store option

### DIFF
--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -38,6 +38,9 @@ struct Cli {
     /// Enable tokio console for debugging
     #[arg(long)]
     debug_console: bool,
+    /// Store auth tokens in ~/.googlepicz/tokens.json instead of the system keyring
+    #[arg(long)]
+    use_file_store: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -69,6 +72,10 @@ enum Commands {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+
+    if cli.use_file_store {
+        std::env::set_var("USE_FILE_STORE", "1");
+    }
 
     let overrides = config::AppConfigOverrides {
         log_level: cli.log_level.clone(),

--- a/app/tests/sync_cli_file_store.rs
+++ b/app/tests/sync_cli_file_store.rs
@@ -1,0 +1,19 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn sync_cli_creates_token_file() {
+    let dir = TempDir::new().unwrap();
+    let token_path = dir.path().join(".googlepicz").join("tokens.json");
+    let mut cmd = Command::cargo_bin("sync_cli").unwrap();
+    cmd.arg("--use-file-store")
+        .arg("sync")
+        .env("MOCK_API_CLIENT", "1")
+        .env("MOCK_ACCESS_TOKEN", "tok")
+        .env("MOCK_REFRESH_TOKEN", "ref")
+        .env("HOME", dir.path());
+    cmd.assert().success().stdout(predicate::str::contains("Finished sync"));
+    assert!(token_path.exists());
+}

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -21,3 +21,4 @@ file-store = ["dirs", "serde", "serde_json"]
 
 [dev-dependencies]
 serial_test = "2"
+tempfile = "3"

--- a/cache/tests/cache_manager.rs
+++ b/cache/tests/cache_manager.rs
@@ -28,7 +28,7 @@ fn test_new_applies_migrations() {
     let version: i64 = conn
         .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 10);
+    assert_eq!(version, 11);
 }
 
 #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -15,3 +15,9 @@ Values can be placed in `~/.googlepicz/config` and are loaded via the [config](h
 Create or edit `~/.googlepicz/config` and provide any of these keys to customize the application. Setting `debug_console = true` turns on Tokio's debugging console.
 
 All settings can also be overridden at runtime using command line options. Run `googlepicz --help` or `sync_cli --help` to see the available flags. The `debug_console` option can be enabled with the `--debug-console` flag.
+
+If the application is built with the optional `file-store` feature, authentication
+tokens may be written to `~/.googlepicz/tokens.json` instead of the system
+keyring. Enable this behaviour by passing `--use-file-store` on the command line
+or by setting the environment variable `USE_FILE_STORE=1` before running the
+tools.


### PR DESCRIPTION
## Summary
- document `file-store` feature and runtime activation
- add `--use-file-store` flag to sync_cli
- support `USE_FILE_STORE` env var in auth
- test file storage behaviour in auth and sync_cli
- update cache schema version test

## Testing
- `cargo test --workspace --all-features`

------
https://chatgpt.com/codex/tasks/task_e_68683d3093808333bca01e4717a24937