### PR TITLE
Handle poisoned mutex in cache

### DIFF
--- a/cache/tests/cache_manager.rs
+++ b/cache/tests/cache_manager.rs
@@ -1,4 +1,4 @@
-use cache::CacheManager;
+use cache::{CacheManager, CacheError};
 use tempfile::NamedTempFile;
 use api_client::{MediaItem, MediaMetadata};
 use chrono::Utc;
@@ -28,7 +28,7 @@ fn test_new_applies_migrations() {
     let version: i64 = conn
         .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 10);
+    assert_eq!(version, 11);
 }
 
 #[test]
@@ -187,4 +187,30 @@ async fn test_async_wrappers() {
     let items = cache.get_all_media_items_async().await.unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].id, item.id);
+}
+
+#[test]
+fn test_poisoned_mutex_returns_error() {
+    let file = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(file.path()).unwrap();
+    let cache_clone = cache.clone();
+    let _ = std::panic::catch_unwind(|| {
+        let _guard = cache_clone.lock_conn().unwrap();
+        panic!("boom");
+    });
+    let result = cache.get_all_media_items();
+    assert!(matches!(result, Err(CacheError::Other(_))));
+}
+
+#[tokio::test]
+async fn test_poisoned_mutex_returns_error_async() {
+    let file = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(file.path()).unwrap();
+    let cache_clone = cache.clone();
+    let _ = std::panic::catch_unwind(|| {
+        let _guard = cache_clone.lock_conn().unwrap();
+        panic!("boom");
+    });
+    let result = cache.get_all_media_items_async().await;
+    assert!(matches!(result, Err(CacheError::Other(_))));
 }


### PR DESCRIPTION
## Summary
- add `lock_conn` helper and use everywhere instead of `unwrap`ing the mutex
- test poisoned mutex behaviour for sync and async methods
- update migration version expectation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68683d283b588333b465de3f7e93bc70