### PR TITLE
Add album management dialogs and search in UI

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -26,6 +26,27 @@ use tokio::time::{sleep, Duration};
 
 const ERROR_DISPLAY_DURATION: Duration = Duration::from_secs(5);
 
+fn parse_date_query(query: &str) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    use chrono::{NaiveDate, TimeZone};
+    if let Some(idx) = query.find("..") {
+        let start_str = &query[..idx];
+        let end_str = &query[idx + 2..];
+        if let (Ok(s), Ok(e)) = (
+            NaiveDate::parse_from_str(start_str, "%Y-%m-%d"),
+            NaiveDate::parse_from_str(end_str, "%Y-%m-%d"),
+        ) {
+            let start = Utc.from_utc_datetime(&s.and_hms_opt(0, 0, 0)?);
+            let end = Utc.from_utc_datetime(&e.and_hms_opt(23, 59, 59)?);
+            return Some((start, end));
+        }
+    } else if let Ok(d) = NaiveDate::parse_from_str(query, "%Y-%m-%d") {
+        let start = Utc.from_utc_datetime(&d.and_hms_opt(0, 0, 0)?);
+        let end = Utc.from_utc_datetime(&d.and_hms_opt(23, 59, 59)?);
+        return Some((start, end));
+    }
+    None
+}
+
 fn error_container_style() -> iced::theme::Container {
     iced::theme::Container::Custom(Box::new(|_theme: &Theme| Appearance {
         text_color: Some(Color::from_rgb(0.5, 0.0, 0.0)),
@@ -75,6 +96,15 @@ pub enum Message {
     AlbumAssigned(Result<(), String>),
     RenameAlbum(String, String),
     DeleteAlbum(String),
+    ShowRenameAlbumDialog(String, String),
+    RenameAlbumTitleChanged(String),
+    ConfirmRenameAlbum,
+    CancelRenameAlbum,
+    ShowDeleteAlbumDialog(String),
+    ConfirmDeleteAlbum,
+    CancelDeleteAlbum,
+    SearchInputChanged(String),
+    PerformSearch,
     ClearErrors,
 }
 
@@ -117,6 +147,10 @@ pub struct GooglePiczUI {
     creating_album: bool,
     new_album_title: String,
     assign_selection: Option<AlbumOption>,
+    renaming_album: Option<String>,
+    rename_album_title: String,
+    deleting_album: Option<String>,
+    search_query: String,
 }
 
 impl GooglePiczUI {
@@ -136,6 +170,22 @@ impl GooglePiczUI {
 
     pub fn album_count(&self) -> usize {
         self.albums.len()
+    }
+
+    pub fn renaming_album(&self) -> Option<String> {
+        self.renaming_album.clone()
+    }
+
+    pub fn deleting_album(&self) -> Option<String> {
+        self.deleting_album.clone()
+    }
+
+    pub fn search_query(&self) -> String {
+        self.search_query.clone()
+    }
+
+    pub fn rename_album_title(&self) -> String {
+        self.rename_album_title.clone()
     }
     fn error_timeout() -> Command<Message> {
         Command::perform(
@@ -210,6 +260,10 @@ impl Application for GooglePiczUI {
             creating_album: false,
             new_album_title: String::new(),
             assign_selection: None,
+            renaming_album: None,
+            rename_album_title: String::new(),
+            deleting_album: None,
+            search_query: String::new(),
         };
 
         (
@@ -492,6 +546,62 @@ impl Application for GooglePiczUI {
                     return GooglePiczUI::error_timeout();
                 }
             }
+            Message::ShowRenameAlbumDialog(id, title) => {
+                self.renaming_album = Some(id);
+                self.rename_album_title = title;
+            }
+            Message::RenameAlbumTitleChanged(t) => {
+                self.rename_album_title = t;
+            }
+            Message::ConfirmRenameAlbum => {
+                if let Some(id) = self.renaming_album.take() {
+                    let title = self.rename_album_title.clone();
+                    self.rename_album_title.clear();
+                    return self.update(Message::RenameAlbum(id, title));
+                }
+            }
+            Message::CancelRenameAlbum => {
+                self.renaming_album = None;
+                self.rename_album_title.clear();
+            }
+            Message::ShowDeleteAlbumDialog(id) => {
+                self.deleting_album = Some(id);
+            }
+            Message::ConfirmDeleteAlbum => {
+                if let Some(id) = self.deleting_album.take() {
+                    return self.update(Message::DeleteAlbum(id));
+                }
+            }
+            Message::CancelDeleteAlbum => {
+                self.deleting_album = None;
+            }
+            Message::SearchInputChanged(q) => {
+                self.search_query = q;
+            }
+            Message::PerformSearch => {
+                if let Some(cm) = &self.cache_manager {
+                    let cm = cm.clone();
+                    let query = self.search_query.clone();
+                    return Command::perform(
+                        async move {
+                            let cache = {
+                                let guard = cm.lock().await;
+                                guard.clone()
+                            };
+                            if let Some((s, e)) = parse_date_query(&query) {
+                                cache
+                                    .get_media_items_by_date_range(s, e)
+                                    .map_err(|e| e.to_string())
+                            } else {
+                                cache
+                                    .get_media_items_by_filename(&query)
+                                    .map_err(|e| e.to_string())
+                            }
+                        },
+                        Message::PhotosLoaded,
+                    );
+                }
+            }
             Message::RenameAlbum(id, title) => {
                 let cache_manager = self.cache_manager.clone();
                 return Command::perform(
@@ -582,13 +692,25 @@ impl Application for GooglePiczUI {
         let mut header = row![
             text("GooglePicz").size(24),
             button("Refresh").on_press(Message::RefreshPhotos),
-            button("New Album…").on_press(Message::ShowCreateAlbumDialog)
+            button("New Album…").on_press(Message::ShowCreateAlbumDialog),
+            text_input("Search", &self.search_query)
+                .on_input(Message::SearchInputChanged),
+            button("Search").on_press(Message::PerformSearch)
         ];
 
         if let Some(album_id) = &self.selected_album {
             header = header
-                .push(button("Rename").on_press(Message::RenameAlbum(album_id.clone(), "Renamed".into())))
-                .push(button("Delete").on_press(Message::DeleteAlbum(album_id.clone())));
+                .push(
+                    button("Rename").on_press(Message::ShowRenameAlbumDialog(
+                        album_id.clone(),
+                        self.albums
+                            .iter()
+                            .find(|a| a.id == *album_id)
+                            .and_then(|a| a.title.clone())
+                            .unwrap_or_default(),
+                    )),
+                )
+                .push(button("Delete").on_press(Message::ShowDeleteAlbumDialog(album_id.clone())));
         }
 
         header = header
@@ -642,6 +764,39 @@ impl Application for GooglePiczUI {
             None
         };
 
+        let rename_dialog = if let Some(_) = &self.renaming_album {
+            Some(
+                column![
+                    text_input("New title", &self.rename_album_title)
+                        .on_input(Message::RenameAlbumTitleChanged),
+                    row![
+                        button("Rename").on_press(Message::ConfirmRenameAlbum),
+                        button("Cancel").on_press(Message::CancelRenameAlbum)
+                    ]
+                    .spacing(10)
+                ]
+                .spacing(10),
+            )
+        } else {
+            None
+        };
+
+        let delete_dialog = if self.deleting_album.is_some() {
+            Some(
+                column![
+                    text("Delete album?").size(16),
+                    row![
+                        button("Delete").on_press(Message::ConfirmDeleteAlbum),
+                        button("Cancel").on_press(Message::CancelDeleteAlbum)
+                    ]
+                    .spacing(10)
+                ]
+                .spacing(10),
+            )
+        } else {
+            None
+        };
+
         let content = match &self.state {
             ViewState::Grid => {
                 if self.loading {
@@ -658,8 +813,8 @@ impl Application for GooglePiczUI {
                         let title = album.title.clone().unwrap_or_else(|| "Untitled".to_string());
                         let controls = row![
                             button(text(title.clone())).on_press(Message::SelectAlbum(Some(album.id.clone()))),
-                            button("Rename").on_press(Message::RenameAlbum(album.id.clone(), format!("{}-renamed", title))),
-                            button("Delete").on_press(Message::DeleteAlbum(album.id.clone()))
+                            button("Rename").on_press(Message::ShowRenameAlbumDialog(album.id.clone(), title.clone())),
+                            button("Delete").on_press(Message::ShowDeleteAlbumDialog(album.id.clone()))
                         ]
                         .spacing(5);
                         album_row = album_row.push(controls);
@@ -740,6 +895,12 @@ impl Application for GooglePiczUI {
         }
         base = base.push(content);
         if let Some(d) = album_dialog {
+            base = base.push(d);
+        }
+        if let Some(d) = rename_dialog {
+            base = base.push(d);
+        }
+        if let Some(d) = delete_dialog {
             base = base.push(d);
         }
 

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -76,3 +76,44 @@ fn test_sync_error_added() {
     let _ = ui.update(Message::SyncError(SyncTaskError::Other("boom".into())));
     assert!(ui.error_count() > 0);
 }
+
+#[test]
+#[serial]
+fn test_rename_dialog_state() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let _ = ui.update(Message::ShowRenameAlbumDialog("a1".into(), "Old".into()));
+    assert_eq!(ui.renaming_album(), Some("a1".into()));
+    assert_eq!(ui.rename_album_title(), "Old");
+    let _ = ui.update(Message::CancelRenameAlbum);
+    assert!(ui.renaming_album().is_none());
+}
+
+#[test]
+#[serial]
+fn test_delete_dialog_state() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let _ = ui.update(Message::ShowDeleteAlbumDialog("a1".into()));
+    assert_eq!(ui.deleting_album(), Some("a1".into()));
+    let _ = ui.update(Message::CancelDeleteAlbum);
+    assert!(ui.deleting_album().is_none());
+}
+
+#[test]
+#[serial]
+fn test_search_input() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let _ = ui.update(Message::SearchInputChanged("query".into()));
+    assert_eq!(ui.search_query(), "query");
+}


### PR DESCRIPTION
## Summary
- support renaming and deleting albums through confirmation dialogs
- add search field for filtering photos by filename or date
- expose state helpers for tests
- cover new behaviour in UI unit tests

## Testing
- `cargo test -p ui --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68684b4873848333b3c04face4f6ff5f