### PR TITLE
Improve sync error reporting

### DIFF
--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -36,3 +36,40 @@ async fn test_periodic_sync_reports_error() {
     std::env::remove_var("MOCK_ACCESS_TOKEN");
     std::env::remove_var("MOCK_REFRESH_TOKEN");
 }
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_periodic_sync_progress_send_failure_forwarded() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_ACCESS_TOKEN", "token");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "refresh");
+    // create syncer with mocked API success
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    let file = NamedTempFile::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut syncer = Syncer::new(file.path()).await.unwrap();
+            // remove API mocking so periodic sync fails when calling the network
+            std::env::remove_var("MOCK_API_CLIENT");
+            let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
+            let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
+            let (handle, shutdown) =
+                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx);
+            // consume the Started event then drop receiver to cause send failure later
+            let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
+            assert!(matches!(start, Some(SyncProgress::Started)));
+            drop(prog_rx);
+            // first error is from periodic sync failing, second from progress send failure
+            let first = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
+            assert!(first.is_some());
+            let second = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
+            assert!(second.is_some());
+            let _ = shutdown.send(());
+            let _ = handle.await;
+        })
+        .await;
+    std::env::remove_var("MOCK_KEYRING");
+    std::env::remove_var("MOCK_ACCESS_TOKEN");
+    std::env::remove_var("MOCK_REFRESH_TOKEN");
+}


### PR DESCRIPTION
## Summary
- log errors and send them to the UI in periodic sync
- log errors and forward them in token refresh task
- test additional error paths

## Testing
- `cargo test --workspace --no-fail-fast -- --nocapture` *(fails: `sync_cli_file_store`)*

------
https://chatgpt.com/codex/tasks/task_e_68684b44cac8833385c769aae58efc40