### PR TITLE
Add benchmark for loading 10k cache items

### DIFF
--- a/cache/benches/cache_bench.rs
+++ b/cache/benches/cache_bench.rs
@@ -33,6 +33,20 @@ fn bench_load_all(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_load_all);
+fn bench_load_all_10k(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..10_000u32 {
+        let item = sample_media_item(&i.to_string());
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("load_all_10k", |b| {
+        b.iter(|| {
+            let _ = cache.get_all_media_items().unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_load_all, bench_load_all_10k);
 criterion_main!(benches);
 

--- a/docs/cache_benchmark_results.md
+++ b/docs/cache_benchmark_results.md
@@ -11,3 +11,7 @@ The `load_all_1000` benchmark represents the time to fetch all items after inser
 
 Benchmark result (1000 items): ~0.99 ms per load.
 
+The `load_all_10k` benchmark loads all items after inserting 10,000 entries.
+
+Benchmark result (10k items): ~15.7 ms per load.
+


### PR DESCRIPTION
## Summary
- add a new `load_all_10k` benchmark
- document benchmark results for 10k items

## Testing
- `cargo bench -p cache --bench cache_bench -- --warm-up-time 1 --measurement-time 3`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6868f74965108333b8ff79f08e8f2468