### PR TITLE
Update docs for OAuth setup and token store

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## 🚧 Project Status: Early Development
 
-This project is currently in active development and not yet ready for production use. We're building a native desktop solution to fill the gap left by Google's lack of official desktop clients.
+This project is **experimental** and not yet ready for production use. We're building a native desktop solution to fill the gap left by Google's lack of official desktop clients. Planned features like video playback, advanced search and face recognition are still under development.
 
 ## 🎯 Project Goals
 
@@ -23,6 +23,11 @@ This project is currently in active development and not yet ready for production
 - ⚡ GPU-accelerated image rendering
 - 📂 Local cache for offline access
 - 🎨 Cross-platform UI with Iced
+
+### Planned Features
+- Video playback
+- Advanced search capabilities
+- Face recognition and tagging
 
 ## 🛠️ Technical Stack
 
@@ -41,7 +46,7 @@ cd GooglePicz
 
 ## 🚀 Quick Start
 
-1. Create OAuth credentials in the [Google Cloud Console](https://console.developers.google.com/).
+1. [Create OAuth credentials](#setting-up-oauth-credentials).
 2. Export the required environment variables so the application can authenticate:
 
 ```bash
@@ -62,6 +67,26 @@ cargo run --package googlepicz --bin sync_cli -- sync
 ```
 
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for optional settings via `AppConfig`.
+
+### Setting up OAuth Credentials
+
+1. Sign in to the [Google Cloud Console](https://console.developers.google.com/) and create a new project.
+2. Enable the **Google Photos Library API** for that project.
+3. Configure an **OAuth consent screen** (External) and add your user as a tester.
+4. Create new **OAuth client credentials** of type **Desktop application**.
+5. Note the generated **client ID** and **client secret**.
+6. Export the credentials so the application can authenticate:
+
+```bash
+export GOOGLE_CLIENT_ID="your_client_id"
+export GOOGLE_CLIENT_SECRET="your_client_secret"
+```
+
+Now you can run the application as shown above.
+
+### Token Storage
+
+Authentication tokens are stored in the system keyring by default. If the application is compiled with the optional `file-store` feature you can persist tokens in `~/.googlepicz/tokens.json` instead by passing `--use-file-store` or setting `USE_FILE_STORE=1` before launching.
 
 ## ❓ Troubleshooting
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -5,7 +5,7 @@ GooglePicz is a native Google Photos client being developed in Rust. The applica
 
 ## 🚧 Project Status: Early Development
 
-**Note**: This project is currently in active development. The information in this documentation reflects the current state and is subject to change as development progresses.
+**Note**: GooglePicz is an **experimental** project. The information in this documentation reflects the current state and is subject to change as development progresses. Planned features include video playback, advanced search and face recognition.
 
 ## 🏗️ Architecture
 
@@ -142,6 +142,22 @@ The application and packaging scripts rely on several environment variables:
 - `LINUX_SIGN_KEY` – GPG key ID used to sign the generated `.deb` package (optional).
 - `MOCK_REFRESH_TOKEN` – Used only for automated tests to bypass live authentication.
 - `MOCK_COMMANDS` – Skips running external tools during packaging tests.
+- `USE_FILE_STORE` – When set to `1` and the optional `file-store` feature is enabled, tokens are written to `~/.googlepicz/tokens.json` instead of the system keyring. The same behaviour can be triggered with the `--use-file-store` flag.
+
+### Setting up OAuth Credentials
+
+1. Open the [Google Cloud Console](https://console.developers.google.com/) and create a new project.
+2. Enable the **Google Photos Library API** for this project.
+3. Configure an **OAuth consent screen** and add your Google account as a test user.
+4. Create new **OAuth client credentials** of type **Desktop application**.
+5. Note the generated **client ID** and **client secret** and export them:
+
+```bash
+export GOOGLE_CLIENT_ID="your_client_id"
+export GOOGLE_CLIENT_SECRET="your_client_secret"
+```
+
+These variables must be set whenever you run the application or tests.
 
 ### Packaging installers
 Run the packager binary to create platform specific artifacts. The version is


### PR DESCRIPTION
## Summary
- clarify experimental nature of the project
- list planned features
- add step-by-step instructions for creating OAuth credentials
- document the `--use-file-store` flag and `USE_FILE_STORE` variable

## Testing
- `cargo fmt --check` *(fails: rustfmt component missing)*
- `cargo clippy --all -- -D warnings` *(fails: clippy component missing)*
- `cargo test` *(interrupted due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6868f74ae4b48333b2389d2a751861f5