### PR TITLE
Add packager artifact step and optional real packaging tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Verify metadata and artifacts
         run: cargo run --package packaging --bin ci_checks
 
+      - name: Run packager
+        run: cargo run --package packaging --bin packager
+
       - name: Upload Linux artifact
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4

--- a/docs/RELEASE_ARTIFACTS.md
+++ b/docs/RELEASE_ARTIFACTS.md
@@ -42,3 +42,10 @@ Environment variables:
 
 These paths include the workspace version from `Cargo.toml` to guarantee
 reproducible artifact names across Linux, macOS and Windows.
+
+### GitHub Actions
+
+The workflow in `.github/workflows/rust.yml` runs the packager on
+Linux, macOS and Windows. Each run uploads the generated `.deb`, `.dmg`
+and Windows installer via `upload-artifact`. You can download these
+artifacts from the workflow run page without building them locally.

--- a/packaging/tests/package_all.rs
+++ b/packaging/tests/package_all.rs
@@ -7,7 +7,10 @@ use std::fs;
 #[test]
 #[serial]
 fn test_package_all_mock() {
-    std::env::set_var("MOCK_COMMANDS", "1");
+    let use_real = std::env::var("CI_PACKAGING_TOOLS").is_ok();
+    if !use_real {
+        std::env::set_var("MOCK_COMMANDS", "1");
+    }
     let root = get_project_root();
 
     if cfg!(target_os = "linux") {
@@ -53,7 +56,9 @@ fn test_package_all_mock() {
         fs::remove_file(exe).unwrap();
     }
 
-    std::env::remove_var("MOCK_COMMANDS");
+    if !use_real {
+        std::env::remove_var("MOCK_COMMANDS");
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- run packager again in the workflow and upload artifacts
- allow real commands in `package_all` tests when `CI_PACKAGING_TOOLS` is set
- note GitHub Actions artifact info in the release docs

## Testing
- `cargo test -p packaging`

------
https://chatgpt.com/codex/tasks/task_e_686911b3c0e88333ba1c06c7f00ecbd2