### PR TITLE
Fix compiler warnings

### DIFF
--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -2,11 +2,8 @@ use std::path::PathBuf;
 
 pub struct AppConfig {
     pub log_level: String,
-    #[allow(dead_code)]
     pub oauth_redirect_port: u16,
-    #[allow(dead_code)]
     pub thumbnails_preload: usize,
-    #[allow(dead_code)]
     pub sync_interval_minutes: u64,
     pub debug_console: bool,
     pub cache_path: PathBuf,

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -28,9 +28,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "file-store")]
 use serde_json;
 
-/// Environment variable that forces using the file-based token store when the
-/// `file-store` feature is compiled in.
-const USE_FILE_STORE_ENV: &str = "USE_FILE_STORE";
 
 const KEYRING_SERVICE_NAME: &str = "GooglePicz";
 const ACCESS_TOKEN_EXPIRY_KEY: &str = "access_token_expiry";

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -401,7 +401,7 @@ impl CacheManager {
     }
 
     pub fn get_favorite_media_items(&self) -> Result<Vec<api_client::MediaItem>, CacheError> {
-        let mut conn = self.lock_conn()?;
+        let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
                 "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename


### PR DESCRIPTION
## Summary
- fix unused variable warning in `CacheManager`
- remove unused constant in `auth`
- clean up unnecessary `allow(dead_code)` annotations in `app` config

## Testing
- `cargo check --workspace`
- `cargo clippy --all` *(fails: `cargo-clippy` not installed)*
- `cargo fmt` *(fails: `rustfmt` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686911afa3d88333a1eb6c376e5c87ff