### PR TITLE
Add headless sync test

### DIFF
--- a/app/tests/googlepicz_headless_sync.rs
+++ b/app/tests/googlepicz_headless_sync.rs
@@ -1,0 +1,35 @@
+use assert_cmd::cargo::cargo_bin;
+use cache::CacheManager;
+use tempfile::TempDir;
+use tokio::{process::Command, time::{timeout, Duration}};
+
+#[tokio::test]
+async fn googlepicz_headless_sync() {
+    // Setup temporary home directory
+    let dir = TempDir::new().expect("temp dir");
+
+    let bin = cargo_bin("googlepicz");
+
+    let mut child = Command::new("xvfb-run");
+    child.arg("-a")
+        .arg(bin)
+        .arg("--sync-interval-minutes").arg("1")
+        .env("MOCK_API_CLIENT", "1")
+        .env("MOCK_KEYRING", "1")
+        .env("MOCK_ACCESS_TOKEN", "token")
+        .env("MOCK_REFRESH_TOKEN", "refresh")
+        .env("GOOGLE_CLIENT_ID", "id")
+        .env("GOOGLE_CLIENT_SECRET", "secret")
+        .env("HOME", dir.path());
+    let mut child = child.spawn().expect("spawn googlepicz");
+
+    let _ = timeout(Duration::from_secs(10), child.wait())
+        .await
+        .expect("process timed out")
+        .expect("failed to wait");
+
+    let db_path = dir.path().join(".googlepicz").join("cache.sqlite");
+    let cache = CacheManager::new(&db_path).expect("open cache");
+    let items = cache.get_all_media_items().expect("read items");
+    assert!(!items.is_empty(), "Cache should contain media items");
+}


### PR DESCRIPTION
## Summary
- add integration test that launches `googlepicz` with `xvfb-run`
- mock OAuth flow and verify that cache gets populated

## Testing
- `cargo test --test googlepicz_headless_sync -- --nocapture`
- `cargo test --workspace --exclude packaging`

------
https://chatgpt.com/codex/tasks/task_e_686911b5876083338b4ac72e3a66488b