### PR TITLE
Add video metadata and simple playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+dependencies = [
+ "async-lock 3.4.0",
+ "blocking",
+ "futures-lite 2.6.0",
+]
+
+[[package]]
 name = "async-global-executor"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +427,17 @@ dependencies = [
  "event-listener 5.4.0",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io 2.4.1",
+ "blocking",
+ "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -563,6 +585,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 
 [[package]]
 name = "atty"
@@ -1057,6 +1085,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,7 +1471,7 @@ dependencies = [
  "log",
  "rangemap",
  "rustc-hash",
- "rustybuzz",
+ "rustybuzz 0.11.0",
  "self_cell",
  "swash",
  "sys-locale",
@@ -1613,6 +1651,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core 0.9.11",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "deranged"
@@ -2068,7 +2112,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree",
+ "roxmltree 0.20.0",
 ]
 
 [[package]]
@@ -2237,6 +2281,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-time"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6404853a6824881fe5f7d662d147dc4e84ecd2259ba0378f272a71dab600758a"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-io 1.13.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2357,16 @@ dependencies = [
 
 [[package]]
 name = "gif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
@@ -2314,6 +2380,19 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gio-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "git2"
@@ -2344,6 +2423,51 @@ name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glib"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39650279f135469465018daae0ba53357942a5212137515777d5fdca74984a44"
+dependencies = [
+ "bitflags 2.9.1",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5"
+dependencies = [
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "glob"
@@ -2394,6 +2518,17 @@ dependencies = [
  "etagere",
  "lru",
  "wgpu",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -2469,6 +2604,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "gstreamer"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d14f5b75598fa79c864803786b4b242adddbf2b86cbc378df9b7b8a1c5cf53"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "glib",
+ "gstreamer-sys",
+ "itertools 0.13.0",
+ "libc",
+ "muldiv",
+ "num-integer",
+ "num-rational",
+ "once_cell",
+ "option-operations",
+ "paste",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gstreamer-app"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1363313eb1931d66ac0b82c9b477fdd066af9dc118ea844966f85b6d99f261fd"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "glib",
+ "gstreamer",
+ "gstreamer-app-sys",
+ "gstreamer-base",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-app-sys"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed667453517b47754b9f9d28c096074e5d565f1cc48c6fa2483b1ea10d7688d3"
+dependencies = [
+ "glib-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-base"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d55668b23fc69f1843daa42b43d289c00fe38e9586c5453b134783d2dd75a3"
+dependencies = [
+ "atomic_refcell",
+ "cfg-if",
+ "glib",
+ "gstreamer",
+ "gstreamer-base-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-base-sys"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5448abb00c197e3ad306710293bf757303cbeab4036b5ccad21c7642b8bf00c9"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-sys"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f147e7c6bc9313d5569eb15da61f6f64026ec69791922749de230583a07286"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer_iced"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0dde1394098fdbafeaf2189f9d056910ab2adad3ec7b81216871293724e82d"
+dependencies = [
+ "anyhow",
+ "futures",
+ "futures-time",
+ "gstreamer",
+ "gstreamer-app",
+ "iced",
+ "smol",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -2922,8 +3166,9 @@ dependencies = [
  "bytemuck",
  "cosmic-text",
  "iced_graphics",
- "kurbo",
+ "kurbo 0.10.4",
  "log",
+ "resvg",
  "rustc-hash",
  "softbuffer",
  "tiny-skia",
@@ -2945,6 +3190,7 @@ dependencies = [
  "iced_graphics",
  "log",
  "once_cell",
+ "resvg",
  "wgpu",
 ]
 
@@ -3108,13 +3354,19 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif",
+ "gif 0.13.3",
  "jpeg-decoder",
  "num-traits",
  "png",
  "qoi",
  "tiff",
 ]
+
+[[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
 name = "indexmap"
@@ -3256,6 +3508,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3370,6 +3631,15 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "kurbo"
@@ -3725,6 +3995,12 @@ dependencies = [
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "muldiv"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "mutate_once"
@@ -4186,6 +4462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "option-operations"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
+dependencies = [
+ "paste",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4433,7 +4718,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -4844,6 +5129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rctree"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
+
+[[package]]
 name = "read-fonts"
 version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4986,6 +5277,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7980f653f9a7db31acff916a262c3b78c562919263edea29bf41a056e20497"
+dependencies = [
+ "gif 0.12.0",
+ "jpeg-decoder",
+ "log",
+ "pico-args",
+ "png",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5008,6 +5325,15 @@ dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
  "serde",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -5138,6 +5464,22 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cd15fef9112a1f94ac64b58d1e4628192631ad6af4dc69997f995459c874e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser 0.19.2",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -5452,6 +5794,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +5928,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel 2.4.0",
+ "async-executor",
+ "async-fs 2.1.2",
+ "async-io 2.4.1",
+ "async-lock 3.4.0",
+ "async-net",
+ "async-process 2.3.1",
+ "blocking",
+ "futures-lite 2.6.0",
+]
+
+[[package]]
 name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5657,6 +6031,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "string_cache"
@@ -5738,6 +6115,16 @@ name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
+
+[[package]]
+name = "svgtypes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71499ff2d42f59d26edb21369a308ede691421f79ebc0f001e2b1fd3a7c9e52"
+dependencies = [
+ "kurbo 0.9.5",
+ "siphasher 0.3.11",
+]
 
 [[package]]
 name = "swash"
@@ -5838,6 +6225,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.8.23",
+ "version-compare",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5846,6 +6246,12 @@ dependencies = [
  "filetime",
  "libc",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -6416,6 +6822,7 @@ dependencies = [
  "chrono",
  "dirs",
  "futures",
+ "gstreamer_iced",
  "httpmock",
  "iced",
  "reqwest",
@@ -6477,6 +6884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6504,6 +6917,67 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usvg"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51daa774fe9ee5efcf7b4fec13019b8119cda764d9a8b5b06df02bb1445c656"
+dependencies = [
+ "base64 0.21.7",
+ "log",
+ "pico-args",
+ "usvg-parser",
+ "usvg-text-layout",
+ "usvg-tree",
+ "xmlwriter",
+]
+
+[[package]]
+name = "usvg-parser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c88a5ffaa338f0e978ecf3d4e00d8f9f493e29bed0752e1a808a1db16afc40"
+dependencies = [
+ "data-url",
+ "flate2",
+ "imagesize",
+ "kurbo 0.9.5",
+ "log",
+ "roxmltree 0.18.1",
+ "simplecss",
+ "siphasher 0.3.11",
+ "svgtypes",
+ "usvg-tree",
+]
+
+[[package]]
+name = "usvg-text-layout"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2374378cb7a3fb8f33894e0fdb8625e1bbc4f25312db8d91f862130b541593"
+dependencies = [
+ "fontdb",
+ "kurbo 0.9.5",
+ "log",
+ "rustybuzz 0.10.0",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "usvg-tree",
+]
+
+[[package]]
+name = "usvg-tree"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cacb0c5edeaf3e80e5afcf5b0d4004cc1d36318befc9a7c6606507e5d0f4062"
+dependencies = [
+ "rctree",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
 ]
 
 [[package]]
@@ -6541,6 +7015,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -7565,6 +8045,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7626,7 +8118,7 @@ checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
 dependencies = [
  "async-broadcast",
  "async-executor",
- "async-fs",
+ "async-fs 1.6.0",
  "async-io 1.13.0",
  "async-lock 2.8.0",
  "async-process 1.8.1",

--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -22,7 +22,17 @@ pub struct MediaMetadata {
     pub creation_time: String,
     pub width: String,
     pub height: String,
-    // Other fields like photo, video can be added if needed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub video: Option<VideoMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoMetadata {
+    pub camera_make: Option<String>,
+    pub camera_model: Option<String>,
+    pub fps: Option<f32>,
+    pub status: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -102,6 +112,7 @@ impl ApiClient {
                 creation_time: "2023-01-01T00:00:00Z".into(),
                 width: "1".into(),
                 height: "1".into(),
+                video: None,
             },
             filename: format!("{}.jpg", id),
         }

--- a/app/tests/sync_cli.rs
+++ b/app/tests/sync_cli.rs
@@ -83,6 +83,7 @@ fn sample_item(id: &str) -> api_client::MediaItem {
             creation_time: "2023-01-01T00:00:00Z".into(),
             width: "1".into(),
             height: "1".into(),
+            video: None,
         },
         filename: format!("{}.jpg", id),
     }

--- a/app/tests/sync_cli_album_commands.rs
+++ b/app/tests/sync_cli_album_commands.rs
@@ -25,6 +25,7 @@ fn sample_item(id: &str) -> api_client::MediaItem {
             creation_time: "2023-01-01T00:00:00Z".into(),
             width: "1".into(),
             height: "1".into(),
+            video: None,
         },
         filename: format!("{}.jpg", id),
     }

--- a/cache/benches/cache_bench.rs
+++ b/cache/benches/cache_bench.rs
@@ -14,6 +14,7 @@ fn sample_media_item(id: &str) -> MediaItem {
             creation_time: "2023-01-01T00:00:00Z".into(),
             width: "1".into(),
             height: "1".into(),
+            video: None,
         },
         filename: format!("{}.jpg", id),
     }

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -154,6 +154,13 @@ fn apply_migrations(conn: &mut Connection) -> Result<(), CacheError> {
             "CREATE INDEX IF NOT EXISTS idx_media_items_is_favorite ON media_items (is_favorite);\
              UPDATE schema_version SET version = 11;"
         ),
+        M::up(
+            "ALTER TABLE media_metadata ADD COLUMN camera_make TEXT;\
+             ALTER TABLE media_metadata ADD COLUMN camera_model TEXT;\
+             ALTER TABLE media_metadata ADD COLUMN fps REAL;\
+             ALTER TABLE media_metadata ADD COLUMN status TEXT;\
+             UPDATE schema_version SET version = 12;"
+        ),
     ]);
     migrations
         .to_latest(conn)
@@ -217,9 +224,18 @@ impl CacheManager {
         conn
             .execute(
                 "INSERT OR REPLACE INTO media_metadata (
-                    media_item_id, creation_time, width, height
-                ) VALUES (?1, ?2, ?3, ?4)",
-                params![item.id, creation_ts, width, height],
+                    media_item_id, creation_time, width, height, camera_make, camera_model, fps, status
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    item.id,
+                    creation_ts,
+                    width,
+                    height,
+                    item.media_metadata.video.as_ref().and_then(|v| v.camera_make.clone()),
+                    item.media_metadata.video.as_ref().and_then(|v| v.camera_model.clone()),
+                    item.media_metadata.video.as_ref().and_then(|v| v.fps),
+                    item.media_metadata.video.as_ref().and_then(|v| v.status.clone()),
+                ],
             )
             .map_err(|e| CacheError::DatabaseError(format!("Failed to insert metadata: {}", e)))?;
 
@@ -230,7 +246,7 @@ impl CacheManager {
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
+                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename
                  FROM media_items m
                  JOIN media_metadata md ON m.id = md.media_item_id
                  WHERE m.id = ?1",
@@ -264,8 +280,14 @@ impl CacheManager {
                         let h: i64 = row.get(7).map_err(|e| CacheError::DatabaseError(e.to_string()))?;
                         h.to_string()
                     },
+                    video: Some(api_client::VideoMetadata {
+                        camera_make: row.get(8).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                        camera_model: row.get(9).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                        fps: row.get(10).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                        status: row.get(11).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                    }),
                 },
-                filename: row.get(8).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
+                filename: row.get(12).map_err(|e| CacheError::DatabaseError(e.to_string()))?,
             };
             Ok(Some(item))
         } else {
@@ -278,7 +300,7 @@ impl CacheManager {
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
+                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename
                  FROM media_items m
                  JOIN media_metadata md ON m.id = md.media_item_id",
             )
@@ -299,8 +321,14 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: Some(api_client::VideoMetadata {
+                            camera_make: row.get(8)?,
+                            camera_model: row.get(9)?,
+                            fps: row.get(10)?,
+                            status: row.get(11)?,
+                        }),
                     },
-                    filename: row.get(8)?,
+                    filename: row.get(12)?,
                 })
             })
             .map_err(|e| {
@@ -321,7 +349,7 @@ impl CacheManager {
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
+                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename
                  FROM media_items m
                  JOIN media_metadata md ON m.id = md.media_item_id
                  WHERE m.mime_type = ?1",
@@ -343,8 +371,14 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: Some(api_client::VideoMetadata {
+                            camera_make: row.get(8)?,
+                            camera_model: row.get(9)?,
+                            fps: row.get(10)?,
+                            status: row.get(11)?,
+                        }),
                     },
-                    filename: row.get(8)?,
+                    filename: row.get(12)?,
                 })
             })
             .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items: {}", e)))?;
@@ -363,7 +397,7 @@ impl CacheManager {
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
+                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename
                  FROM media_items m
                  JOIN media_metadata md ON m.id = md.media_item_id
                  WHERE m.filename LIKE ?1",
@@ -385,8 +419,14 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: Some(api_client::VideoMetadata {
+                            camera_make: row.get(8)?,
+                            camera_model: row.get(9)?,
+                            fps: row.get(10)?,
+                            status: row.get(11)?,
+                        }),
                     },
-                    filename: row.get(8)?,
+                    filename: row.get(12)?,
                 })
             })
             .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items: {}", e)))?;
@@ -404,7 +444,7 @@ impl CacheManager {
         let mut conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
+                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename
                  FROM media_items m
                  JOIN media_metadata md ON m.id = md.media_item_id
                  WHERE m.is_favorite = 1",
@@ -426,8 +466,14 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: Some(api_client::VideoMetadata {
+                            camera_make: row.get(8)?,
+                            camera_model: row.get(9)?,
+                            fps: row.get(10)?,
+                            status: row.get(11)?,
+                        }),
                     },
-                    filename: row.get(8)?,
+                    filename: row.get(12)?,
                 })
             })
             .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items: {}", e)))?;
@@ -528,7 +574,7 @@ impl CacheManager {
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
+                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename
                  FROM media_items m
                  JOIN album_media_items ami ON m.id = ami.media_item_id
                  JOIN media_metadata md ON m.id = md.media_item_id
@@ -551,8 +597,14 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: Some(api_client::VideoMetadata {
+                            camera_make: row.get(8)?,
+                            camera_model: row.get(9)?,
+                            fps: row.get(10)?,
+                            status: row.get(11)?,
+                        }),
                     },
-                    filename: row.get(8)?,
+                    filename: row.get(12)?,
                 })
             })
             .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items by album: {}", e)))?;
@@ -570,7 +622,7 @@ impl CacheManager {
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
+                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename
                  FROM media_items m
                  JOIN media_metadata md ON m.id = md.media_item_id
                  WHERE md.creation_time >= ?1 AND md.creation_time <= ?2",
@@ -592,8 +644,14 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: Some(api_client::VideoMetadata {
+                            camera_make: row.get(8)?,
+                            camera_model: row.get(9)?,
+                            fps: row.get(10)?,
+                            status: row.get(11)?,
+                        }),
                     },
-                    filename: row.get(8)?,
+                    filename: row.get(12)?,
                 })
             })
             .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items by date: {}", e)))?;
@@ -770,6 +828,7 @@ mod tests {
                 creation_time: "2023-01-01T00:00:00Z".into(),
                 width: "1".into(),
                 height: "1".into(),
+                video: None,
             },
             filename: format!("{}.jpg", id),
         }

--- a/cache/tests/cache_manager.rs
+++ b/cache/tests/cache_manager.rs
@@ -15,6 +15,7 @@ fn sample_item(id: &str) -> MediaItem {
             creation_time: "2023-01-01T00:00:00Z".into(),
             width: "1".into(),
             height: "1".into(),
+            video: None,
         },
         filename: format!("{}.jpg", id),
     }
@@ -28,7 +29,7 @@ fn test_new_applies_migrations() {
     let version: i64 = conn
         .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 11);
+    assert_eq!(version, 12);
 }
 
 #[test]

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -16,6 +16,7 @@ auth = { path = "../auth" }
 tracing = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
+gstreamer_iced = "0.1"
 futures = "0.3"
 
 [dev-dependencies]

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -23,6 +23,8 @@ use sync::{SyncProgress, SyncTaskError};
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
+use gstreamer_iced::{GstreamerIcedBase, GStreamerMessage, PlayStatus};
+use gstreamer_iced::reexport::url;
 
 const ERROR_DISPLAY_DURATION: Duration = Duration::from_secs(5);
 
@@ -105,6 +107,9 @@ pub enum Message {
     CancelDeleteAlbum,
     SearchInputChanged(String),
     PerformSearch,
+    PlayVideo(MediaItem),
+    VideoEvent(GStreamerMessage),
+    CloseVideo,
     ClearErrors,
 }
 
@@ -120,10 +125,11 @@ impl std::fmt::Display for AlbumOption {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum ViewState {
     Grid,
     SelectedPhoto(MediaItem),
+    PlayingVideo(GstreamerIcedBase),
 }
 
 pub struct GooglePiczUI {
@@ -433,6 +439,24 @@ impl Application for GooglePiczUI {
             Message::ClosePhoto => {
                 self.state = ViewState::Grid;
             }
+            Message::PlayVideo(item) => {
+                let url = format!("{}=dv", item.base_url);
+                if let Ok(mut player) = GstreamerIcedBase::new_url(&url::Url::parse(&url).unwrap(), false) {
+                    player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
+                    self.state = ViewState::PlayingVideo(player);
+                } else {
+                    self.errors.push("Failed to start video".into());
+                    return GooglePiczUI::error_timeout();
+                }
+            }
+            Message::VideoEvent(msg) => {
+                if let ViewState::PlayingVideo(player) = &mut self.state {
+                    return player.update(msg).map(Message::VideoEvent);
+                }
+            }
+            Message::CloseVideo => {
+                self.state = ViewState::Grid;
+            }
             Message::SyncProgress(progress) => match progress {
                 SyncProgress::Started => {
                     self.synced = 0;
@@ -692,6 +716,10 @@ impl Application for GooglePiczUI {
             }));
         }
 
+        if let ViewState::PlayingVideo(player) = &self.state {
+            subs.push(player.subscription().map(Message::VideoEvent));
+        }
+
         Subscription::batch(subs)
     }
 
@@ -884,7 +912,7 @@ impl Application for GooglePiczUI {
                         title: a.title.clone().unwrap_or_else(|| "Untitled".into()),
                     })
                     .collect();
-                column![
+                let mut col = column![
                     header,
                     button("Close").on_press(Message::ClosePhoto),
                     img,
@@ -893,6 +921,20 @@ impl Application for GooglePiczUI {
                         self.assign_selection.clone(),
                         Message::AlbumPicked
                     )
+                ];
+                if photo.mime_type.starts_with("video/") {
+                    col = col.push(button("Play Video").on_press(Message::PlayVideo(photo.clone())));
+                }
+                col
+            }
+            ViewState::PlayingVideo(player) => {
+                let frame = player
+                    .frame_handle()
+                    .unwrap_or_else(|| image::Handle::from_pixels(1, 1, vec![0, 0, 0, 0]));
+                column![
+                    header,
+                    button("Close").on_press(Message::CloseVideo),
+                    image(frame).width(Length::Fill).height(Length::Fill)
                 ]
             }
         };

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -16,6 +16,7 @@ fn sample_item() -> MediaItem {
             creation_time: "2023-01-01T00:00:00Z".into(),
             width: "1".into(),
             height: "1".into(),
+            video: None,
         },
         filename: "1.jpg".into(),
     }


### PR DESCRIPTION
## Summary
- extend `MediaMetadata` with `VideoMetadata`
- add video columns/migration in cache
- add Play Video functionality in UI using `gstreamer_iced`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686911b2c3e483338a724898860c334f