### PR TITLE
Refactor GitHub workflows

### DIFF
--- a/.github/actions/checks/action.yml
+++ b/.github/actions/checks/action.yml
@@ -1,0 +1,13 @@
+name: Rust checks
+runs:
+  using: "composite"
+  steps:
+    - name: Format check
+      run: cargo fmt -- --check
+      shell: bash
+    - name: Clippy check
+      run: cargo clippy --all -- -D warnings
+      shell: bash
+    - name: Run tests
+      run: cargo test --all
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Format check
-        run: cargo fmt --check
-
-      - name: Clippy check
-        run: cargo clippy --all -- -D warnings
-
-      - name: Run tests
-        run: cargo test
+      - uses: ./.github/actions/checks
 
   packaging-tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,10 +3,14 @@ name: Rust CI
 on:
   push:
     branches: ["main"]
+    tags: ['*']
   pull_request:
+  release:
+    types: [published]
 
 jobs:
   package:
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -53,14 +57,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Format check
-        run: cargo fmt -- --check
-
-      - name: Clippy check
-        run: cargo clippy -- -D warnings
-
-      - name: Run tests
-        run: cargo test --all
+      - uses: ./.github/actions/checks
 
       - name: Build release
         run: cargo build --release --package googlepicz


### PR DESCRIPTION
## Summary
- centralize common Rust checks in `.github/actions/checks`
- reuse the new composite action in both CI workflows
- limit packaging job to tags or release events

## Testing
- `cargo test -p packaging`
- `cargo fmt --all -- --check` *(fails: rustfmt missing)*

------
https://chatgpt.com/codex/tasks/task_e_686927856eb08333b5af1ee0cf079851