### PR TITLE
Implement video controls with mock gstreamer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6832,6 +6832,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "url",
  "wgpu",
 ]
 

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -513,6 +513,7 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: None,
                     },
                     filename: row.get(8)?,
                 })

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -16,8 +16,9 @@ auth = { path = "../auth" }
 tracing = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
-gstreamer_iced = "0.1"
+gstreamer_iced = { version = "0.1", optional = true }
 futures = "0.3"
+url = "2.5"
 
 [dev-dependencies]
 httpmock = "0.6"
@@ -25,5 +26,8 @@ tempfile = "3"
 serial_test = "2"
 
 [features]
+default = ["gst"]
 trace-spans = []
+gst = ["gstreamer_iced"]
+mock-gst = []
 

--- a/ui/tests/video_control.rs
+++ b/ui/tests/video_control.rs
@@ -1,0 +1,61 @@
+use ui::{GooglePiczUI, Message};
+use iced::Application;
+use tempfile::tempdir;
+use serial_test::serial;
+use api_client::{MediaItem, MediaMetadata};
+
+fn sample_video() -> MediaItem {
+    MediaItem {
+        id: "v1".to_string(),
+        description: None,
+        product_url: "http://example.com".into(),
+        base_url: "http://example.com/video".into(),
+        mime_type: "video/mp4".into(),
+        media_metadata: MediaMetadata {
+            creation_time: "2023-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+            video: None,
+        },
+        filename: "v1.mp4".into(),
+    }
+}
+
+#[test]
+#[serial]
+fn test_video_play_pause_stop() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let item = sample_video();
+
+    let _ = ui.update(Message::PlayVideo(item.clone()));
+    assert!(ui.state_debug().starts_with("PlayingVideo"));
+    assert_eq!(ui.video_status(), "Playing");
+
+    let _ = ui.update(Message::VideoPause);
+    assert_eq!(ui.video_status(), "Paused");
+
+    let _ = ui.update(Message::VideoPlay);
+    assert_eq!(ui.video_status(), "Playing");
+
+    let _ = ui.update(Message::VideoStop);
+    assert_eq!(ui.state_debug(), "Grid");
+}
+
+#[test]
+#[serial]
+fn test_video_bus_end() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let item = sample_video();
+    let _ = ui.update(Message::PlayVideo(item));
+    let _ = ui.update(Message::VideoEvent(ui::GStreamerMessage::BusGoToEnd));
+    assert_eq!(ui.state_debug(), "Grid");
+    assert_eq!(ui.video_status(), "Finished");
+}


### PR DESCRIPTION
## Summary
- provide a mock `gstreamer_iced` implementation used for tests
- add play/pause/stop handling with status text in the UI
- expose new video control messages and buttons
- include integration tests for basic video control logic
- fix missing video field in cache and update dependencies

## Testing
- `cargo test -p ui --no-default-features --features mock-gst`

------
https://chatgpt.com/codex/tasks/task_e_686927843b4883339218261467ea29b5