### PR TITLE
Refactor UI module structure

### DIFF
--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -513,6 +513,7 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: None,
                     },
                     filename: row.get(8)?,
                 })

--- a/ui/src/dialog.rs
+++ b/ui/src/dialog.rs
@@ -1,0 +1,27 @@
+use iced::widget::container::Appearance;
+use iced::{Border, Color, Theme};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlbumOption {
+    pub(crate) id: String,
+    pub(crate) title: String,
+}
+
+impl std::fmt::Display for AlbumOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.title)
+    }
+}
+
+pub fn error_container_style() -> iced::theme::Container {
+    iced::theme::Container::Custom(Box::new(|_theme: &Theme| Appearance {
+        text_color: Some(Color::from_rgb(0.5, 0.0, 0.0)),
+        background: Some(Color::from_rgb(1.0, 0.9, 0.9).into()),
+        border: Border {
+            color: Color::from_rgb(0.8, 0.0, 0.0),
+            width: 1.0,
+            radius: 2.0.into(),
+        },
+        shadow: Default::default(),
+    }))
+}

--- a/ui/src/search.rs
+++ b/ui/src/search.rs
@@ -1,0 +1,44 @@
+use chrono::{DateTime, Utc};
+
+pub fn parse_date_query(query: &str) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    use chrono::{NaiveDate, TimeZone};
+    if let Some(idx) = query.find("..") {
+        let start_str = &query[..idx];
+        let end_str = &query[idx + 2..];
+        if let (Ok(s), Ok(e)) = (
+            NaiveDate::parse_from_str(start_str, "%Y-%m-%d"),
+            NaiveDate::parse_from_str(end_str, "%Y-%m-%d"),
+        ) {
+            let start = Utc.from_utc_datetime(&s.and_hms_opt(0, 0, 0)?);
+            let end = Utc.from_utc_datetime(&e.and_hms_opt(23, 59, 59)?);
+            return Some((start, end));
+        }
+    } else if let Ok(d) = NaiveDate::parse_from_str(query, "%Y-%m-%d") {
+        let start = Utc.from_utc_datetime(&d.and_hms_opt(0, 0, 0)?);
+        let end = Utc.from_utc_datetime(&d.and_hms_opt(23, 59, 59)?);
+        return Some((start, end));
+    }
+    None
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchMode {
+    Filename,
+    Favoriten,
+    DateRange,
+}
+
+impl SearchMode {
+    pub const ALL: [SearchMode; 3] = [SearchMode::Filename, SearchMode::Favoriten, SearchMode::DateRange];
+}
+
+impl std::fmt::Display for SearchMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            SearchMode::Filename => "Filename",
+            SearchMode::Favoriten => "Favoriten",
+            SearchMode::DateRange => "Datum von/bis",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/ui/src/video.rs
+++ b/ui/src/video.rs
@@ -1,0 +1,11 @@
+pub use gstreamer_iced::{GstreamerIcedBase as VideoPlayer, GStreamerMessage, PlayStatus};
+pub use gstreamer_iced::reexport::url;
+
+pub fn start_video(url: &url::Url) -> Option<VideoPlayer> {
+    if let Ok(mut player) = VideoPlayer::new_url(url, false) {
+        let _ = player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
+        Some(player)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
## Summary
- split search functions and types into `search.rs`
- extract album dialog utilities into `dialog.rs`
- add video helper module `video.rs`
- update UI to use new modules
- fix cache compile issue with new metadata

## Testing
- `cargo test -p ui --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6869278096248333bd7b231c8f4cbd43