### PR TITLE
Improve sync error reporting

### DIFF
--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -91,3 +91,37 @@ async fn test_periodic_sync_progress_send_failure_forwarded() {
     std::env::remove_var("MOCK_ACCESS_TOKEN");
     std::env::remove_var("MOCK_REFRESH_TOKEN");
 }
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_periodic_sync_reports_cache_error() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_ACCESS_TOKEN", "token");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "refresh");
+    // create syncer with mocked API success
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    let file = NamedTempFile::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut syncer = Syncer::new(file.path()).await.unwrap();
+            {
+                let conn = syncer.cache_manager.lock_conn().unwrap();
+                conn.execute("DROP TABLE last_sync", []).unwrap();
+            }
+            std::env::remove_var("MOCK_API_CLIENT");
+            let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
+            let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
+            let (handle, shutdown) =
+                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx);
+            let _ = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
+            let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
+            assert!(matches!(err, Some(SyncTaskError::Other(msg)) if msg.contains("last sync")));
+            let _ = shutdown.send(());
+            let _ = handle.await;
+        })
+        .await;
+    std::env::remove_var("MOCK_KEYRING");
+    std::env::remove_var("MOCK_ACCESS_TOKEN");
+    std::env::remove_var("MOCK_REFRESH_TOKEN");
+}

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -80,6 +80,32 @@ fn test_sync_error_added() {
 
 #[test]
 #[serial]
+fn test_sync_failed_message() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let _ = ui.update(Message::SyncFailed("fail".into()));
+    assert_eq!(ui.sync_status(), "Sync error");
+    assert!(ui.error_count() > 0);
+}
+
+#[test]
+#[serial]
+fn test_sync_retry_message() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let _ = ui.update(Message::SyncRetry(5));
+    assert!(ui.sync_status().contains("Retrying"));
+    assert_eq!(ui.error_count(), 0);
+}
+
+#[test]
+#[serial]
 fn test_rename_dialog_state() {
     let dir = tempdir().unwrap();
     std::env::set_var("HOME", dir.path());


### PR DESCRIPTION
## Summary
- report last sync retrieval errors through channel in `start_periodic_sync`
- expose new UI messages `SyncFailed` and `SyncRetry`
- show retry or failure status in UI and expose sync status for tests
- cover new behaviour with extra tests

## Testing
- `cargo test --all --quiet` *(fails: failed to run custom build command for `glib-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_686927817a60833389c41e5a3fd60466