### PR TITLE
Fix compile warnings

### DIFF
--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -488,7 +488,7 @@ impl CacheManager {
     }
 
     pub fn get_media_items_by_favorite(&self, fav: bool) -> Result<Vec<api_client::MediaItem>, CacheError> {
-        let mut conn = self.lock_conn()?;
+        let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
                 "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, m.filename
@@ -513,6 +513,7 @@ impl CacheManager {
                         creation_time: Self::ts_to_rfc3339(ts),
                         width: w.to_string(),
                         height: h.to_string(),
+                        video: None,
                     },
                     filename: row.get(8)?,
                 })

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -150,9 +150,7 @@ impl std::fmt::Display for SearchMode {
     }
 }
 
-#[derive(Debug, Clone)]
-
-
+#[derive(Debug)]
 enum ViewState {
     Grid,
     SelectedPhoto(MediaItem),
@@ -475,7 +473,7 @@ impl Application for GooglePiczUI {
             Message::PlayVideo(item) => {
                 let url = format!("{}=dv", item.base_url);
                 if let Ok(mut player) = GstreamerIcedBase::new_url(&url::Url::parse(&url).unwrap(), false) {
-                    player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
+                    let _ = player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
                     self.state = ViewState::PlayingVideo(player);
                 } else {
                     self.errors.push("Failed to start video".into());


### PR DESCRIPTION
## Summary
- resolve missing `video` field in `CacheManager::get_media_items_by_favorite`
- remove unused mut in cache
- drop `Clone` requirement from `ViewState`
- ignore unused command when starting video playback

## Testing
- `cargo check --all`
- `cargo build`
- `cargo clippy --all` *(failed: component missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869278058a0833381b68e2fba3e0a45