### PR TITLE
Add cache export/import commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,8 +4518,10 @@ dependencies = [
 name = "packaging"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "cargo-bundle-licenses",
  "cargo-deb",
+ "predicates 2.1.5",
  "serde_json",
  "serial_test",
  "thiserror 1.0.69",

--- a/app/tests/sync_cli_export_import.rs
+++ b/app/tests/sync_cli_export_import.rs
@@ -1,0 +1,61 @@
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::process::Command;
+use tempfile::tempdir;
+use cache::CacheManager;
+
+fn build_cmd(home: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("sync_cli").unwrap();
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("MOCK_REFRESH_TOKEN", "t");
+    cmd.env("HOME", home);
+    cmd
+}
+
+fn sample_item(id: &str) -> api_client::MediaItem {
+    api_client::MediaItem {
+        id: id.to_string(),
+        description: Some("desc".into()),
+        product_url: "http://example.com".into(),
+        base_url: "http://example.com/base".into(),
+        mime_type: "image/jpeg".into(),
+        media_metadata: api_client::MediaMetadata {
+            creation_time: "2023-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+            video: None,
+        },
+        filename: format!("{}.jpg", id),
+    }
+}
+
+#[test]
+fn export_and_import_items() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&base).unwrap();
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).unwrap();
+    let item = sample_item("1");
+    cache.insert_media_item(&item).unwrap();
+
+    let export_file = dir.path().join("items.json");
+    build_cmd(dir.path())
+        .args(&["export-items", "--file", export_file.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(contains("Exported"));
+
+    cache.clear_cache().unwrap();
+
+    build_cmd(dir.path())
+        .args(&["import-items", "--file", export_file.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(contains("Imported"));
+
+    let items = cache.get_all_media_items().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].id, item.id);
+}

--- a/app/tests/sync_cli_list_items.rs
+++ b/app/tests/sync_cli_list_items.rs
@@ -1,0 +1,58 @@
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::process::Command;
+use tempfile::tempdir;
+use cache::CacheManager;
+
+fn build_cmd(home: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("sync_cli").unwrap();
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("MOCK_REFRESH_TOKEN", "test");
+    cmd.env("HOME", home);
+    cmd
+}
+
+fn sample_item(id: &str) -> api_client::MediaItem {
+    api_client::MediaItem {
+        id: id.to_string(),
+        description: Some("desc".into()),
+        product_url: "http://example.com".into(),
+        base_url: "http://example.com/base".into(),
+        mime_type: "image/jpeg".into(),
+        media_metadata: api_client::MediaMetadata {
+            creation_time: "2023-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+            video: None,
+        },
+        filename: format!("{}.jpg", id),
+    }
+}
+
+#[test]
+fn list_items_no_cache() {
+    let dir = tempdir().unwrap();
+    build_cmd(dir.path())
+        .arg("list-items")
+        .assert()
+        .success()
+        .stdout(contains("No cache found"));
+}
+
+#[test]
+fn list_items_shows_entries() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&base).unwrap();
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).unwrap();
+    let item = sample_item("1");
+    cache.insert_media_item(&item).unwrap();
+
+    build_cmd(dir.path())
+        .args(&["list-items", "--limit", "1"])
+        .assert()
+        .success()
+        .stdout(contains("1 - 1.jpg"));
+}

--- a/cache/tests/cache_manager.rs
+++ b/cache/tests/cache_manager.rs
@@ -23,6 +23,23 @@ fn sample_item(id: &str) -> MediaItem {
 }
 
 #[test]
+fn export_and_import_roundtrip() {
+    let file = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(file.path()).unwrap();
+    let item = sample_item("1");
+    cache.insert_media_item(&item).unwrap();
+
+    let export_file = NamedTempFile::new().unwrap();
+    cache.export_media_items(export_file.path()).unwrap();
+    cache.clear_cache().unwrap();
+    cache.import_media_items(export_file.path()).unwrap();
+
+    let items = cache.get_all_media_items().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].id, item.id);
+}
+
+#[test]
 fn test_new_applies_migrations() {
     let file = NamedTempFile::new().unwrap();
     let _ = CacheManager::new(file.path()).unwrap();

--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -13,6 +13,9 @@ serde_json = "1"
 
 [dev-dependencies]
 serial_test = "2"
+# Needed for running binary integration tests
+assert_cmd = "2"
+predicates = "2"
 # Required for building Debian packages
 cargo-deb = "3.1"
 [build-dependencies]

--- a/packaging/tests/ci_checks_bin.rs
+++ b/packaging/tests/ci_checks_bin.rs
@@ -1,0 +1,30 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use packaging::utils::{get_project_root, workspace_version};
+use serial_test::serial;
+use std::fs;
+
+#[test]
+#[serial]
+fn test_ci_checks_binary() -> Result<(), Box<dyn std::error::Error>> {
+    let version = workspace_version()?;
+    let root = get_project_root();
+
+    #[cfg(target_os = "linux")]
+    let path = root.join(format!("GooglePicz-{}.deb", version));
+    #[cfg(target_os = "macos")]
+    let path = root.join(format!("target/release/GooglePicz-{}.dmg", version));
+    #[cfg(target_os = "windows")]
+    let path = root.join(format!("target/windows/GooglePicz-{}-Setup.exe", version));
+
+    fs::create_dir_all(path.parent().unwrap())?;
+    fs::write(&path, b"test")?;
+
+    Command::cargo_bin("ci_checks")?
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("CI checks passed"));
+
+    fs::remove_file(path)?;
+    Ok(())
+}

--- a/packaging/tests/cleanup.rs
+++ b/packaging/tests/cleanup.rs
@@ -1,0 +1,25 @@
+use packaging::utils::get_project_root;
+use packaging::clean_artifacts;
+use serial_test::serial;
+use std::fs;
+
+#[test]
+#[serial]
+fn test_clean_artifacts() -> Result<(), Box<dyn std::error::Error>> {
+    let root = get_project_root();
+
+    #[cfg(target_os = "linux")]
+    let path = root.join("GooglePicz-temp.deb");
+    #[cfg(target_os = "macos")]
+    let path = root.join("target/release/GooglePicz-temp.dmg");
+    #[cfg(target_os = "windows")]
+    let path = root.join("target/windows/GooglePicz-temp-Setup.exe");
+
+    fs::create_dir_all(path.parent().unwrap())?;
+    fs::write(&path, b"test")?;
+
+    clean_artifacts()?;
+
+    assert!(!path.exists(), "expected {:?} to be removed", path);
+    Ok(())
+}

--- a/packaging/tests/utils.rs
+++ b/packaging/tests/utils.rs
@@ -1,0 +1,42 @@
+use packaging::utils::{
+    get_project_root,
+    workspace_version,
+    verify_metadata_package_name,
+    verify_artifact_names,
+};
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn test_workspace_version_and_metadata() -> Result<(), Box<dyn std::error::Error>> {
+    // workspace_version should parse the version from the top-level Cargo.toml
+    let version = workspace_version()?;
+    assert!(!version.is_empty(), "version should not be empty");
+
+    // verify_metadata_package_name should find the googlepicz package
+    verify_metadata_package_name("googlepicz")?;
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_verify_artifact_names() -> Result<(), Box<dyn std::error::Error>> {
+    let version = workspace_version()?;
+    let root = get_project_root();
+
+    // create dummy artifact based on target OS
+    #[cfg(target_os = "linux")]
+    let path = root.join(format!("GooglePicz-{}.deb", version));
+    #[cfg(target_os = "macos")]
+    let path = root.join(format!("target/release/GooglePicz-{}.dmg", version));
+    #[cfg(target_os = "windows")]
+    let path = root.join(format!("target/windows/GooglePicz-{}-Setup.exe", version));
+
+    std::fs::create_dir_all(path.parent().unwrap())?;
+    std::fs::write(&path, b"test")?;
+
+    verify_artifact_names()?;
+
+    std::fs::remove_file(path)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- allow exporting/importing cache items via `CacheManager`
- expose new `export-items` and `import-items` subcommands in `sync_cli`
- cover the new functionality with unit and integration tests
- fix minor clippy warning in `get_media_items_by_favorite`

## Testing
- `cargo check -p cache`
- `cargo test -p cache`
- `cargo check -p packaging`
- `cargo test -p packaging`
- `cargo test -p googlepicz` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686932e83b008333b071fdd8e3e5b9e5