### PR TITLE
Define USE_FILE_STORE_ENV constant

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -33,6 +33,8 @@ const KEYRING_SERVICE_NAME: &str = "GooglePicz";
 const ACCESS_TOKEN_EXPIRY_KEY: &str = "access_token_expiry";
 /// Seconds before expiry when we proactively refresh the token.
 pub const REFRESH_MARGIN_SECS: u64 = 300;
+/// Environment variable to opt into storing tokens in a file instead of the keyring.
+pub const USE_FILE_STORE_ENV: &str = "USE_FILE_STORE";
 
 static SCHEDULED_REFRESH: Lazy<Mutex<Option<JoinHandle<()>>>> =
     Lazy::new(|| Mutex::new(None));


### PR DESCRIPTION
## Summary
- expose `USE_FILE_STORE_ENV` in the auth crate so callers can refer to the environment variable

## Testing
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686943f337b883339dc6450e8e44c9ff