### PR TITLE
Enhanced periodic sync logging

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -149,10 +149,10 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
 
             let (err_tx, err_rx) = tokio::sync::mpsc::unbounded_channel::<SyncTaskError>();
             let (sync_handle, sync_shutdown) = if ensure_access_token_valid().await.is_ok() {
-                syncer.start_periodic_sync(interval, tx, err_tx.clone())
+                syncer.start_periodic_sync(interval, tx, err_tx.clone(), None)
             } else {
                 error!("❌ Cannot start periodic sync without a valid token");
-                syncer.start_periodic_sync(interval, tx, err_tx.clone())
+                syncer.start_periodic_sync(interval, tx, err_tx.clone(), None)
             };
 
             let (refresh_handle, refresh_shutdown) =

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -21,7 +21,7 @@ async fn test_periodic_sync_reports_error() {
             std::env::remove_var("MOCK_API_CLIENT");
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
-            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx);
+            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None);
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));
             let retry = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
@@ -66,7 +66,7 @@ async fn test_periodic_sync_progress_send_failure_forwarded() {
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
             let (handle, shutdown) =
-                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx);
+                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None);
             // consume the Started event then drop receiver to cause send failure later
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));

--- a/sync/tests/repeated_failures.rs
+++ b/sync/tests/repeated_failures.rs
@@ -1,0 +1,41 @@
+use sync::{Syncer, SyncTaskError};
+use serial_test::serial;
+use tempfile::NamedTempFile;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_periodic_sync_repeated_failures_reported() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_ACCESS_TOKEN", "token");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "refresh");
+    // build syncer with mocked API first
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    let file = NamedTempFile::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut syncer = Syncer::new(file.path()).await.unwrap();
+            // drop mock so periodic sync fails
+            std::env::remove_var("MOCK_API_CLIENT");
+            let (prog_tx, _prog_rx) = mpsc::unbounded_channel();
+            let (err_tx, _err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
+            let (status_tx, mut status_rx) = mpsc::unbounded_channel::<u32>();
+            let (handle, shutdown) = syncer.start_periodic_sync(
+                Duration::from_millis(10),
+                prog_tx,
+                err_tx,
+                Some(status_tx),
+            );
+            let first = timeout(Duration::from_secs(5), status_rx.recv()).await.unwrap().unwrap();
+            let second = timeout(Duration::from_secs(5), status_rx.recv()).await.unwrap().unwrap();
+            assert!(first == 1 && second >= 2);
+            let _ = shutdown.send(());
+            let _ = handle.await;
+        })
+        .await;
+    std::env::remove_var("MOCK_KEYRING");
+    std::env::remove_var("MOCK_ACCESS_TOKEN");
+    std::env::remove_var("MOCK_REFRESH_TOKEN");
+}


### PR DESCRIPTION
## Summary
- extend periodic sync signature with optional status channel
- track consecutive failures and escalate logging
- pass new parameter in main and tests
- add regression test for repeated failures

## Testing
- `cargo check -p sync --quiet`
- `cargo test --all --quiet` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686943f5b79083338d49486e2c9eedc5