### PR TITLE
Add Linux library setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ Having trouble starting the application? Here are a few common issues:
 - **Packaging errors** – The packager relies on external tools like `cargo deb` and `makensis`. Use the `MOCK_COMMANDS` environment variable to run packaging tests without these tools.
 - **Developing without network access** – Set `MOCK_API_CLIENT=1` and `MOCK_KEYRING=1` (and optionally `MOCK_ACCESS_TOKEN`/`MOCK_REFRESH_TOKEN`) to run all tests without hitting Google APIs.
 - **Need more insight into async tasks?** – Set `debug_console = true` in `~/.googlepicz/config` or pass `--debug-console` to print detailed Tokio diagnostics.
+- **Missing system libraries on Linux** – Install `glib2.0-dev`, `gstreamer1.0-dev` and `libssl-dev` (or the equivalent packages for your distribution). On Debian/Ubuntu run:
+
+  ```bash
+  sudo apt install glib2.0-dev gstreamer1.0-dev libssl-dev
+  ```
+
+  On Fedora/RHEL use:
+
+  ```bash
+  sudo dnf install glib2-devel gstreamer1-devel openssl-devel
+  ```
+
+  Missing these libraries can lead to build failures about unavailable headers.
 
 ## 📑 Logs and Error Reports
 

--- a/docs/RELEASE_ARTIFACTS.md
+++ b/docs/RELEASE_ARTIFACTS.md
@@ -6,6 +6,17 @@ This document describes how to build installers for all supported platforms.
 
 - Rust toolchain installed (`rustup`)
 - Required signing credentials if you want signed binaries
+- Development libraries on Linux such as `glib2.0-dev`, `gstreamer1.0-dev` and `libssl-dev` (or distribution equivalents). For example:
+
+  ```bash
+  sudo apt install glib2.0-dev gstreamer1.0-dev libssl-dev
+  ```
+
+  On Fedora/RHEL run:
+
+  ```bash
+  sudo dnf install glib2-devel gstreamer1-devel openssl-devel
+  ```
 
 ### Required Tools {#required-tools}
 


### PR DESCRIPTION
## Summary
- describe Linux system library requirements in README troubleshooting
- add the same guidance to RELEASE_ARTIFACTS.md for CI

## Testing
- `cargo test --workspace --no-run` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686943f448a08333998584e12da8fd91