### PR TITLE
Add metadata viewing and album export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,6 +2545,7 @@ dependencies = [
  "console-subscriber",
  "dirs",
  "predicates 2.1.5",
+ "serde_json",
  "sync",
  "tempfile",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -158,11 +158,13 @@ See the following documents for additional details:
 
 Run the `sync_cli` binary for manual synchronization or to inspect the local cache.
 Like the GUI, it reads settings from `~/.googlepicz/config` via `AppConfig` and supports
-the same command line overrides (e.g. `--log-level debug`).
+the same command line overrides (e.g. `--log-level debug`). Available options include
+`--oauth-redirect-port`, `--thumbnails-preload`, `--sync-interval-minutes`, `--config`,
+`--debug-console` and `--use-file-store`.
 The tool exposes subcommands for `sync`, `status`, `clear-cache`, `list-albums`,
-`create-album`, `delete-album` and `cache-stats` and prints progress updates
-to stdout while downloading items. The source code lives in
-`app/src/bin/sync_cli.rs`.
+`create-album`, `delete-album`, `cache-stats`, `list-items`, `show-item`,
+`export-items`, `import-items` and `export-albums` and prints progress updates
+to stdout while downloading items. The source code lives in `app/src/bin/sync_cli.rs`.
 
 ```bash
 cargo run --package googlepicz --bin sync_cli -- sync
@@ -211,6 +213,36 @@ cargo run --package googlepicz --bin sync_cli -- cache-stats
 ```
 
 Shows how many albums and media items are cached locally.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- list-items --limit 5
+```
+
+Lists cached media items, optionally limiting the output.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- show-item ITEM_ID
+```
+
+Displays the JSON metadata for a single cached media item.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- export-items --file items.json
+```
+
+Exports all cached media items to a file.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- import-items --file items.json
+```
+
+Imports media items from a file.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- export-albums --file albums.json
+```
+
+Exports all cached albums to a file.
 
 ## Packaging & Signing
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -18,6 +18,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
 clap = { workspace = true }
+serde_json = "1"
 
 [build-dependencies]
 cargo-bundle-licenses = "0.4"

--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -73,8 +73,19 @@ enum Commands {
         #[arg(long)]
         limit: Option<usize>,
     },
+    /// Show metadata for a cached media item
+    ShowItem {
+        /// ID of the media item
+        id: String,
+    },
     /// Export all cached media items to a JSON file
     ExportItems {
+        /// Path to the export file
+        #[arg(long)]
+        file: PathBuf,
+    },
+    /// Export all cached albums to a JSON file
+    ExportAlbums {
         /// Path to the export file
         #[arg(long)]
         file: PathBuf,
@@ -215,6 +226,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("{} - {}", item.id, item.filename);
             }
         }
+        Commands::ShowItem { id } => {
+            if !db_path.exists() {
+                println!("No cache found at {:?}", db_path);
+                return Ok(());
+            }
+            let cache = CacheManager::new(&db_path)?;
+            if let Some(item) = cache.get_media_item(&id)? {
+                println!("{}", serde_json::to_string_pretty(&item)?);
+            } else {
+                println!("Item not found: {}", id);
+            }
+        }
         Commands::ExportItems { file } => {
             if !db_path.exists() {
                 println!("No cache found at {:?}", db_path);
@@ -223,6 +246,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let cache = CacheManager::new(&db_path)?;
             cache.export_media_items(&file)?;
             println!("Exported to {:?}", file);
+        }
+        Commands::ExportAlbums { file } => {
+            if !db_path.exists() {
+                println!("No cache found at {:?}", db_path);
+                return Ok(());
+            }
+            let cache = CacheManager::new(&db_path)?;
+            cache.export_albums(&file)?;
+            println!("Exported albums to {:?}", file);
         }
         Commands::ImportItems { file } => {
             if !db_path.exists() {

--- a/app/tests/sync_cli_show_item_export_albums.rs
+++ b/app/tests/sync_cli_show_item_export_albums.rs
@@ -1,0 +1,86 @@
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::process::Command;
+use tempfile::tempdir;
+use cache::CacheManager;
+use serde_json;
+
+fn build_cmd(home: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("sync_cli").unwrap();
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("MOCK_REFRESH_TOKEN", "test");
+    cmd.env("HOME", home);
+    cmd
+}
+
+fn sample_item(id: &str) -> api_client::MediaItem {
+    api_client::MediaItem {
+        id: id.to_string(),
+        description: Some("desc".into()),
+        product_url: "http://example.com".into(),
+        base_url: "http://example.com/base".into(),
+        mime_type: "image/jpeg".into(),
+        media_metadata: api_client::MediaMetadata {
+            creation_time: "2023-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+            video: None,
+        },
+        filename: format!("{}.jpg", id),
+    }
+}
+
+fn sample_album(id: &str) -> api_client::Album {
+    api_client::Album {
+        id: id.into(),
+        title: Some("Album".into()),
+        product_url: None,
+        is_writeable: None,
+        media_items_count: None,
+        cover_photo_base_url: None,
+        cover_photo_media_item_id: None,
+    }
+}
+
+#[test]
+fn show_item_outputs_metadata() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&base).unwrap();
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).unwrap();
+    let item = sample_item("1");
+    cache.insert_media_item(&item).unwrap();
+
+    build_cmd(dir.path())
+        .args(&["show-item", "1"])
+        .assert()
+        .success()
+        .stdout(contains("\"id\": \"1\""));
+}
+
+#[test]
+fn export_albums_writes_file() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&base).unwrap();
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).unwrap();
+    let album = sample_album("1");
+    cache.insert_album(&album).unwrap();
+
+    let export_file = dir.path().join("albums.json");
+    build_cmd(dir.path())
+        .args(&["export-albums", "--file", export_file.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(contains("Exported albums"));
+
+    let exported: Vec<api_client::Album> = serde_json::from_reader(
+        std::fs::File::open(&export_file).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(exported.len(), 1);
+    assert_eq!(exported[0].id, album.id);
+}

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -871,6 +871,14 @@ impl CacheManager {
             .map_err(|e| CacheError::SerializationError(e.to_string()))
     }
 
+    pub fn export_albums<P: AsRef<Path>>(&self, path: P) -> Result<(), CacheError> {
+        let albums = self.get_all_albums()?;
+        let file = std::fs::File::create(path.as_ref())
+            .map_err(|e| CacheError::Other(format!("Failed to create export file: {}", e)))?;
+        serde_json::to_writer(file, &albums)
+            .map_err(|e| CacheError::SerializationError(e.to_string()))
+    }
+
     pub fn import_media_items<P: AsRef<Path>>(&self, path: P) -> Result<(), CacheError> {
         let file = std::fs::File::open(path.as_ref())
             .map_err(|e| CacheError::Other(format!("Failed to open import file: {}", e)))?;
@@ -920,6 +928,16 @@ impl CacheManager {
     {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.export_media_items(path))
+            .await
+            .map_err(|e| CacheError::Other(e.to_string()))?
+    }
+
+    pub async fn export_albums_async<P>(&self, path: P) -> Result<(), CacheError>
+    where
+        P: AsRef<Path> + Send + 'static,
+    {
+        let this = self.clone();
+        tokio::task::spawn_blocking(move || this.export_albums(path))
             .await
             .map_err(|e| CacheError::Other(e.to_string()))?
     }


### PR DESCRIPTION
## Summary
- allow exporting cached albums and viewing single item metadata in sync_cli
- document new sync_cli commands and global options
- test new commands with mocked environment

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68694a670f5483339fd00f5dd465a823