### PR TITLE
Add e2e test crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "e2e"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "cache",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "cache",
     "sync",
     "packaging",
+    "tests/e2e",
 ]
 
 [workspace.package]

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "e2e"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+assert_cmd = "2"
+tokio = { version = "1", features = ["full"] }
+tempfile = "3"
+cache = { path = "../../cache" }
+
+[[test]]
+name = "googlepicz_e2e"
+path = "tests/googlepicz_e2e.rs"
+harness = false

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -1,0 +1,1 @@
+// E2E tests crate

--- a/tests/e2e/tests/googlepicz_e2e.rs
+++ b/tests/e2e/tests/googlepicz_e2e.rs
@@ -1,0 +1,35 @@
+use assert_cmd::cargo::cargo_bin;
+use cache::CacheManager;
+use tokio::{process::Command, time::{timeout, Duration}};
+use tempfile::TempDir;
+
+#[tokio::main]
+async fn main() {
+    // Setup temporary home directory
+    let dir = TempDir::new().expect("temp dir");
+
+    let bin = cargo_bin("googlepicz");
+
+    let mut child = Command::new("xvfb-run");
+    child.arg("-a")
+        .arg(bin)
+        .arg("--sync-interval-minutes").arg("1")
+        .env("MOCK_API_CLIENT", "1")
+        .env("MOCK_KEYRING", "1")
+        .env("MOCK_ACCESS_TOKEN", "token")
+        .env("MOCK_REFRESH_TOKEN", "refresh")
+        .env("GOOGLE_CLIENT_ID", "id")
+        .env("GOOGLE_CLIENT_SECRET", "secret")
+        .env("HOME", dir.path());
+    let mut child = child.spawn().expect("spawn googlepicz");
+
+    let _ = timeout(Duration::from_secs(10), child.wait())
+        .await
+        .expect("process timed out")
+        .expect("failed to wait");
+
+    let db_path = dir.path().join(".googlepicz").join("cache.sqlite");
+    let cache = CacheManager::new(&db_path).expect("open cache");
+    let items = cache.get_all_media_items().expect("read items");
+    assert!(!items.is_empty(), "Cache should contain media items");
+}


### PR DESCRIPTION
## Summary
- add a new e2e test crate under `tests/e2e`
- run GooglePicz with mocked OAuth in headless mode and check the cache

## Testing
- `cargo test -p packaging`
- `cargo test -p e2e`

------
https://chatgpt.com/codex/tasks/task_e_68694a67f6308333b1082b50c8b26884