### PR TITLE
Add checksums generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,9 @@ jobs:
 
       - name: Run packaging tests
         run: cargo test -p packaging
+      - name: Upload checksums
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksums-${{ runner.os }}
+          path: checksums.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,6 +4524,7 @@ dependencies = [
  "predicates 2.1.5",
  "serde_json",
  "serial_test",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.5.11",

--- a/packaging/Cargo.toml
+++ b/packaging/Cargo.toml
@@ -10,6 +10,7 @@ toml = "0.5"
 thiserror = { workspace = true }
 which = "4"
 serde_json = "1"
+sha2 = "0.10"
 
 [dev-dependencies]
 serial_test = "2"

--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -374,7 +374,8 @@ pub fn package_all() -> Result<(), PackagingError> {
     clean_artifacts()?;
     bundle_licenses()?;
     build_release()?;
-    create_installer()
+    create_installer()?;
+    utils::write_checksums()
 }
 
 #[cfg(test)]

--- a/packaging/tests/package_all.rs
+++ b/packaging/tests/package_all.rs
@@ -56,6 +56,9 @@ fn test_package_all_mock() {
         fs::remove_file(exe).unwrap();
     }
 
+    let checksums = root.join("checksums.txt");
+    assert!(checksums.exists(), "Expected {:?} to exist", checksums);
+
     if !use_real {
         std::env::remove_var("MOCK_COMMANDS");
     }

--- a/packaging/tests/utils.rs
+++ b/packaging/tests/utils.rs
@@ -3,6 +3,7 @@ use packaging::utils::{
     workspace_version,
     verify_metadata_package_name,
     verify_artifact_names,
+    write_checksums,
 };
 use serial_test::serial;
 
@@ -36,6 +37,31 @@ fn test_verify_artifact_names() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::write(&path, b"test")?;
 
     verify_artifact_names()?;
+
+    std::fs::remove_file(path)?;
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_write_checksums() -> Result<(), Box<dyn std::error::Error>> {
+    let version = workspace_version()?;
+    let root = get_project_root();
+
+    #[cfg(target_os = "linux")]
+    let path = root.join(format!("GooglePicz-{}.deb", version));
+    #[cfg(target_os = "macos")]
+    let path = root.join(format!("target/release/GooglePicz-{}.dmg", version));
+    #[cfg(target_os = "windows")]
+    let path = root.join(format!("target/windows/GooglePicz-{}-Setup.exe", version));
+
+    std::fs::create_dir_all(path.parent().unwrap())?;
+    std::fs::write(&path, b"test")?;
+
+    write_checksums()?;
+
+    let checksums = std::fs::read_to_string(root.join("checksums.txt"))?;
+    assert!(checksums.contains(path.file_name().unwrap().to_str().unwrap()));
 
     std::fs::remove_file(path)?;
     Ok(())


### PR DESCRIPTION
## Summary
- add `write_checksums` to generate SHA256 hashes for installer artifacts
- run checksum creation in `package_all`
- upload `checksums.txt` in CI workflow
- update tests for new functionality

## Testing
- `cargo test -p packaging -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_68694a68db748333b4bd8d7aa49ad336