### PR TITLE
Add cross-platform packaging workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Run packaging tests
         run: cargo test -p packaging
+      - name: Run CI checks
+        run: cargo run --package packaging --bin ci_checks
       - name: Upload checksums
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -1,0 +1,69 @@
+name: Packager
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  packager:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      MAC_SIGN_ID: ${{ secrets.MAC_SIGN_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      WINDOWS_CERT: ${{ secrets.WINDOWS_CERT }}
+      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Install platform tools
+        if: runner.os == 'Windows'
+        run: choco install nsis -y
+      - name: Install cargo-bundle
+        if: runner.os == 'macOS'
+        run: cargo install cargo-bundle
+      - name: Install cargo-deb
+        if: runner.os == 'Linux'
+        run: cargo install cargo-deb
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Run packager
+        run: cargo run --package packaging --bin packager
+      - name: Run CI checks
+        run: cargo run --package packaging --bin ci_checks
+      - name: Upload Linux artifact
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: googlepicz-linux
+          path: GooglePicz-*.deb
+      - name: Upload macOS artifact
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v4
+        with:
+          name: googlepicz-macos
+          path: target/release/GooglePicz-*.dmg
+      - name: Upload Windows artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: googlepicz-windows
+          path: target/windows/GooglePicz-*-Setup.exe


### PR DESCRIPTION
## Summary
- verify required packaging tools in `packaging` crate
- run CI checks in packaging CI workflow
- add new `packager` workflow for Linux, macOS and Windows

## Testing
- `cargo check -p packaging`
- `cargo test -p packaging`

------
https://chatgpt.com/codex/tasks/task_e_68695c594bc48333a23b6975379aa975