### PR TITLE
Fix warnings and document workspace build

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -48,3 +48,8 @@
 - Corrected a duplicate `eprintln!` call in `Message::PhotosLoaded` handler in `ui/src/lib.rs`.
 - Removed a redundant closing brace (`}}`) in the `update` method in `ui/src/lib.rs` to fix a syntax error.
 - Created `targetpicture.md` in `docs/` detailing the final vision and architecture of the project.
+
+## 2025-07-05
+- Fixed compilation errors in `sync` crate by returning `Ok(())` from async blocks.
+- Handled unused `Command` warning in `ui` crate.
+- Workspace builds successfully with `cargo check --all` and `cargo build`.

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -297,6 +297,7 @@ impl Syncer {
                             }
                             sleep(interval).await;
                         }
+                        Ok::<(), SyncTaskError>(())
                     } => {}
                 }
             }
@@ -354,6 +355,7 @@ impl Syncer {
                             last_success = Utc::now();
                             failures = 0;
                         }
+                        Ok::<(), SyncTaskError>(())
                     } => {}
                 }
             }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -520,7 +520,7 @@ impl Application for GooglePiczUI {
             Message::PlayVideo(item) => {
                 let url = format!("{}=dv", item.base_url);
                 if let Ok(mut player) = GstreamerIcedBase::new_url(&url::Url::parse(&url).unwrap(), false) {
-                    player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
+                    let _ = player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
                     self.state = ViewState::PlayingVideo(player);
                 } else {
                     let msg = "Failed to start video".to_string();


### PR DESCRIPTION
## Summary
- fix unused Command in `ui` crate
- ensure async blocks return `Ok(())` in `sync` crate
- document build success in changelog

## Testing
- `cargo check --all`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68695c4fac44833382e7dd138f069953