### PR TITLE
Extend sync_cli with search and album management

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ the same command line overrides (e.g. `--log-level debug`). Available options in
 `--oauth-redirect-port`, `--thumbnails-preload`, `--sync-interval-minutes`, `--config`,
 `--debug-console` and `--use-file-store`.
 The tool exposes subcommands for `sync`, `status`, `clear-cache`, `list-albums`,
-`create-album`, `delete-album`, `cache-stats`, `list-items`, `show-item`,
+`create-album`, `delete-album`, `rename-album`, `add-to-album`, `list-album-items`,
+`cache-stats`, `list-items`, `search`, `show-item`,
 `export-items`, `import-items` and `export-albums` and prints progress updates
 to stdout while downloading items. The source code lives in `app/src/bin/sync_cli.rs`.
 
@@ -211,6 +212,24 @@ cargo run --package googlepicz --bin sync_cli -- delete-album ALBUM_ID
 Deletes the album from Google Photos and the local cache.
 
 ```bash
+cargo run --package googlepicz --bin sync_cli -- rename-album ALBUM_ID "New Title"
+```
+
+Renames an existing album on Google Photos and updates the cache.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- add-to-album ALBUM_ID ITEM_ID
+```
+
+Associates a cached media item with an album in the local database.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- list-album-items ALBUM_ID
+```
+
+Lists cached items that belong to the given album.
+
+```bash
 cargo run --package googlepicz --bin sync_cli -- cache-stats
 ```
 
@@ -221,6 +240,12 @@ cargo run --package googlepicz --bin sync_cli -- list-items --limit 5
 ```
 
 Lists cached media items, optionally limiting the output.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- search QUERY
+```
+
+Searches cached media items by filename or description.
 
 ```bash
 cargo run --package googlepicz --bin sync_cli -- show-item ITEM_ID

--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -99,6 +99,36 @@ enum Commands {
         #[arg(long)]
         file: PathBuf,
     },
+    /// Search cached media items
+    Search {
+        /// Query string to match filename or description
+        query: String,
+        /// Maximum number of items to display
+        #[arg(long)]
+        limit: Option<usize>,
+    },
+    /// Rename an album
+    RenameAlbum {
+        /// ID of the album
+        id: String,
+        /// New title
+        title: String,
+    },
+    /// Add a media item to an album
+    AddToAlbum {
+        /// Album ID
+        album_id: String,
+        /// Media item ID
+        item_id: String,
+    },
+    /// List items of an album
+    ListAlbumItems {
+        /// Album ID
+        album_id: String,
+        /// Maximum number of items to display
+        #[arg(long)]
+        limit: Option<usize>,
+    },
 }
 
 #[cfg_attr(feature = "trace-spans", tracing::instrument)]
@@ -267,6 +297,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let cache = CacheManager::new(&db_path)?;
             cache.import_media_items(&file)?;
             println!("Imported from {:?}", file);
+        }
+        Commands::Search { query, limit } => {
+            if !db_path.exists() {
+                println!("No cache found at {:?}", db_path);
+                return Ok(());
+            }
+            let cache = CacheManager::new(&db_path)?;
+            let items = cache.get_media_items_by_text(&query)?;
+            let max = limit.unwrap_or(10);
+            for item in items.iter().take(max) {
+                println!("{} - {}", item.id, item.filename);
+            }
+        }
+        Commands::RenameAlbum { id, title } => {
+            if !db_path.exists() {
+                println!("No cache found at {:?}", db_path);
+                return Ok(());
+            }
+            let token = ensure_access_token_valid().await?;
+            let client = ApiClient::new(token);
+            let album = client.rename_album(&id, &title).await?;
+            let cache = CacheManager::new(&db_path)?;
+            cache.rename_album(&id, &title)?;
+            let shown = album.title.unwrap_or(title);
+            println!("Album renamed: {} (id: {})", shown, id);
+        }
+        Commands::AddToAlbum { album_id, item_id } => {
+            if !db_path.exists() {
+                println!("No cache found at {:?}", db_path);
+                return Ok(());
+            }
+            let cache = CacheManager::new(&db_path)?;
+            cache.associate_media_item_with_album(&item_id, &album_id)?;
+            println!("Added {} to album {}", item_id, album_id);
+        }
+        Commands::ListAlbumItems { album_id, limit } => {
+            if !db_path.exists() {
+                println!("No cache found at {:?}", db_path);
+                return Ok(());
+            }
+            let cache = CacheManager::new(&db_path)?;
+            let items = cache.get_media_items_by_album(&album_id)?;
+            let max = limit.unwrap_or(10);
+            for item in items.iter().take(max) {
+                println!("{} - {}", item.id, item.filename);
+            }
         }
     }
 

--- a/app/tests/sync_cli_extra_commands.rs
+++ b/app/tests/sync_cli_extra_commands.rs
@@ -1,0 +1,124 @@
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::process::Command;
+use tempfile::tempdir;
+use cache::CacheManager;
+
+fn build_cmd(home: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("sync_cli").unwrap();
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("MOCK_REFRESH_TOKEN", "test");
+    cmd.env("HOME", home);
+    cmd
+}
+
+fn sample_item(id: &str) -> api_client::MediaItem {
+    api_client::MediaItem {
+        id: id.to_string(),
+        description: Some("desc".into()),
+        product_url: "http://example.com".into(),
+        base_url: "http://example.com/base".into(),
+        mime_type: "image/jpeg".into(),
+        media_metadata: api_client::MediaMetadata {
+            creation_time: "2023-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+            video: None,
+        },
+        filename: format!("{}.jpg", id),
+    }
+}
+
+fn sample_album(id: &str) -> api_client::Album {
+    api_client::Album {
+        id: id.to_string(),
+        title: Some("Album".into()),
+        product_url: None,
+        is_writeable: None,
+        media_items_count: None,
+        cover_photo_base_url: None,
+        cover_photo_media_item_id: None,
+    }
+}
+
+#[test]
+fn search_items_lists_matches() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&base).unwrap();
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).unwrap();
+    let item = sample_item("1");
+    cache.insert_media_item(&item).unwrap();
+
+    build_cmd(dir.path())
+        .args(&["search", "1"]) 
+        .assert()
+        .success()
+        .stdout(contains("1 - 1.jpg"));
+}
+
+#[test]
+fn rename_album_updates_cache() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&base).unwrap();
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).unwrap();
+    let album = sample_album("1");
+    cache.insert_album(&album).unwrap();
+
+    build_cmd(dir.path())
+        .args(&["rename-album", "1", "Renamed"])
+        .assert()
+        .success()
+        .stdout(contains("Album renamed"));
+
+    let cache = CacheManager::new(&db).unwrap();
+    let albums = cache.get_all_albums().unwrap();
+    assert_eq!(albums[0].title.as_deref(), Some("Renamed"));
+}
+
+#[test]
+fn add_to_album_creates_association() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&base).unwrap();
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).unwrap();
+    let album = sample_album("1");
+    cache.insert_album(&album).unwrap();
+    let item = sample_item("1");
+    cache.insert_media_item(&item).unwrap();
+
+    build_cmd(dir.path())
+        .args(&["add-to-album", "1", "1"])
+        .assert()
+        .success()
+        .stdout(contains("Added 1 to album 1"));
+
+    let cache = CacheManager::new(&db).unwrap();
+    let items = cache.get_media_items_by_album("1").unwrap();
+    assert_eq!(items.len(), 1);
+}
+
+#[test]
+fn list_album_items_outputs_entries() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&base).unwrap();
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).unwrap();
+    let album = sample_album("1");
+    cache.insert_album(&album).unwrap();
+    let item = sample_item("1");
+    cache.insert_media_item(&item).unwrap();
+    cache.associate_media_item_with_album(&item.id, &album.id).unwrap();
+
+    build_cmd(dir.path())
+        .args(&["list-album-items", "1"])
+        .assert()
+        .success()
+        .stdout(contains("1 - 1.jpg"));
+}

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -760,6 +760,19 @@ impl CacheManager {
         Ok(())
     }
 
+    pub fn remove_media_item_from_album(&self, media_item_id: &str, album_id: &str) -> Result<(), CacheError> {
+        let conn = self.lock_conn()?;
+        conn
+            .execute(
+                "DELETE FROM album_media_items WHERE album_id = ?1 AND media_item_id = ?2",
+                params![album_id, media_item_id],
+            )
+            .map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to remove media item from album: {}", e))
+            })?;
+        Ok(())
+    }
+
     pub fn get_media_items_by_album(&self, album_id: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
         let conn = self.lock_conn()?;
         let mut stmt = conn
@@ -1015,6 +1028,18 @@ impl CacheManager {
     ) -> Result<(), CacheError> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || this.associate_media_item_with_album(&media_item_id, &album_id))
+            .await
+            .map_err(|e| CacheError::Other(e.to_string()))?
+    }
+
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self)))]
+    pub async fn remove_media_item_from_album_async(
+        &self,
+        media_item_id: String,
+        album_id: String,
+    ) -> Result<(), CacheError> {
+        let this = self.clone();
+        tokio::task::spawn_blocking(move || this.remove_media_item_from_album(&media_item_id, &album_id))
             .await
             .map_err(|e| CacheError::Other(e.to_string()))?
     }

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -242,6 +242,30 @@ cargo run --package googlepicz --bin sync_cli -- delete-album ALBUM_ID
 Deletes the album from Google Photos and the local cache.
 
 ```bash
+cargo run --package googlepicz --bin sync_cli -- rename-album ALBUM_ID "New Title"
+```
+
+Renames an album on Google Photos and updates the local cache.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- add-to-album ALBUM_ID ITEM_ID
+```
+
+Associates a cached media item with an album.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- list-album-items ALBUM_ID
+```
+
+Lists items stored for the given album.
+
+```bash
+cargo run --package googlepicz --bin sync_cli -- search QUERY
+```
+
+Searches cached media items by filename or description.
+
+```bash
 cargo run --package googlepicz --bin sync_cli -- cache-stats
 ```
 


### PR DESCRIPTION
## Summary
- add CLI subcommands for searching and album operations
- implement cache API to remove an item from an album
- test new commands
- document additional commands in README and DOCUMENTATION

## Testing
- `cargo test -p cache`
- `cargo test` *(fails: glib-2.0 library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68695c509da48333a2f08e0742c51798