### PR TITLE
Implement settings dialog and camera make search

### DIFF
--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -439,6 +439,53 @@ impl CacheManager {
         Ok(items)
     }
 
+    pub fn get_media_items_by_camera_make(&self, make: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename
+                 FROM media_items m
+                 JOIN media_metadata md ON m.id = md.media_item_id
+                 WHERE md.camera_make = ?1",
+            )
+            .map_err(|e| CacheError::DatabaseError(format!("Failed to prepare statement: {}", e)))?;
+
+        let iter = stmt
+            .query_map(params![make], |row| {
+                let ts: i64 = row.get(5)?;
+                let w: i64 = row.get(6)?;
+                let h: i64 = row.get(7)?;
+                Ok(api_client::MediaItem {
+                    id: row.get(0)?,
+                    description: row.get(1)?,
+                    product_url: row.get(2)?,
+                    base_url: row.get(3)?,
+                    mime_type: row.get(4)?,
+                    media_metadata: api_client::MediaMetadata {
+                        creation_time: Self::ts_to_rfc3339(ts),
+                        width: w.to_string(),
+                        height: h.to_string(),
+                        video: Some(api_client::VideoMetadata {
+                            camera_make: row.get(8)?,
+                            camera_model: row.get(9)?,
+                            fps: row.get(10)?,
+                            status: row.get(11)?,
+                        }),
+                    },
+                    filename: row.get(12)?,
+                })
+            })
+            .map_err(|e| CacheError::DatabaseError(format!("Failed to query media items: {}", e)))?;
+
+        let mut items = Vec::new();
+        for item in iter {
+            items.push(item.map_err(|e| {
+                CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e))
+            })?);
+        }
+        Ok(items)
+    }
+
     pub fn get_media_items_by_filename(&self, pattern: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
         let like_pattern = format!("%{}%", pattern);
         let conn = self.lock_conn()?;

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -136,4 +136,21 @@ fn test_search_mode() {
     assert_eq!(ui.search_mode(), SearchMode::MimeType);
     let _ = ui.update(Message::SearchModeChanged(SearchMode::CameraModel));
     assert_eq!(ui.search_mode(), SearchMode::CameraModel);
+    let _ = ui.update(Message::SearchModeChanged(SearchMode::CameraMake));
+    assert_eq!(ui.search_mode(), SearchMode::CameraMake);
+}
+
+#[test]
+#[serial]
+fn test_settings_dialog() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    assert!(!ui.settings_open());
+    let _ = ui.update(Message::ShowSettings);
+    assert!(ui.settings_open());
+    let _ = ui.update(Message::CloseSettings);
+    assert!(!ui.settings_open());
 }


### PR DESCRIPTION
## Summary
- add new SearchMode variant `CameraMake`
- add settings dialog toggle logic in UI
- support querying media items by camera make
- test settings dialog state and new search mode

## Testing
- `cargo test -p ui --no-default-features --features no-gstreamer` *(fails: could not compile `sync`)*

------
https://chatgpt.com/codex/tasks/task_e_68695c5846848333b2fe4a77d09ed82d