### PR TITLE
Improve sync status reporting

### DIFF
--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -145,7 +145,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             });
-            syncer.sync_media_items(Some(tx), None).await?;
+            syncer
+                .sync_media_items(Some(tx), None, None, None)
+                .await?;
         }
         Commands::Status => {
             if !db_path.exists() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -153,14 +153,14 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
 
             let (err_tx, err_rx) = tokio::sync::mpsc::unbounded_channel::<SyncTaskError>();
             let (sync_handle, sync_shutdown) = if ensure_access_token_valid().await.is_ok() {
-                syncer.start_periodic_sync(interval, tx, err_tx.clone(), None)
+                syncer.start_periodic_sync(interval, tx, err_tx.clone(), None, None, None)
             } else {
                 error!("❌ Cannot start periodic sync without a valid token");
-                syncer.start_periodic_sync(interval, tx, err_tx.clone(), None)
+                syncer.start_periodic_sync(interval, tx, err_tx.clone(), None, None, None)
             };
 
             let (refresh_handle, refresh_shutdown) =
-                Syncer::start_token_refresh_task(Duration::from_secs(60), err_tx.clone());
+                Syncer::start_token_refresh_task(Duration::from_secs(60), err_tx.clone(), None);
 
 
             let ui_thread = std::thread::spawn(move || {

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -16,8 +16,9 @@ thiserror = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 serial_test = "2"
-ui = { path = "../ui" }
+ui = { path = "../ui", default-features = false, features = ["no-gstreamer"] }
 iced = { version = "0.12", features = ["wgpu", "tokio", "image"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 
 [features]
 trace-spans = []

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -51,6 +51,11 @@ pub enum SyncTaskError {
 }
 
 impl Syncer {
+    fn forward<T: Clone>(tx: &Option<mpsc::UnboundedSender<T>>, value: T) {
+        if let Some(t) = tx {
+            let _ = t.send(value);
+        }
+    }
     #[cfg_attr(feature = "trace-spans", tracing::instrument)]
     pub async fn new(db_path: &Path) -> Result<Self, SyncError> {
         let access_token = ensure_access_token_valid().await.map_err(|e| {
@@ -73,6 +78,8 @@ impl Syncer {
         &mut self,
         progress: Option<mpsc::UnboundedSender<SyncProgress>>,
         error: Option<mpsc::UnboundedSender<SyncTaskError>>,
+        ui_progress: Option<mpsc::UnboundedSender<SyncProgress>>,
+        ui_error: Option<mpsc::UnboundedSender<SyncTaskError>>,
     ) -> Result<(), SyncError> {
         tracing::info!("Starting media item synchronization...");
         if let Some(tx) = &progress {
@@ -83,8 +90,13 @@ impl Syncer {
                         e
                     )));
                 }
+                Self::forward(&ui_error, SyncTaskError::Other(format!(
+                    "Failed to send progress: {}",
+                    e
+                )));
             }
         }
+        Self::forward(&ui_progress, SyncProgress::Started);
         let mut page_token: Option<String> = None;
         let mut total_synced = 0;
 
@@ -97,6 +109,7 @@ impl Syncer {
                         tracing::error!("Failed to forward error: {}", send_err);
                     }
                 }
+                Self::forward(&ui_error, SyncTaskError::Other(msg.clone()));
                 DateTime::<Utc>::from(std::time::SystemTime::UNIX_EPOCH)
             }
         };
@@ -120,6 +133,7 @@ impl Syncer {
                         tracing::error!("Failed to forward error: {}", send_err);
                     }
                 }
+                Self::forward(&ui_error, SyncTaskError::Other(msg.clone()));
                 SyncError::AuthenticationError(msg)
             })?;
             self.api_client.set_access_token(token);
@@ -135,6 +149,7 @@ impl Syncer {
                             tracing::error!("Failed to forward error: {}", send_err);
                         }
                     }
+                    Self::forward(&ui_error, SyncTaskError::Other(msg.clone()));
                     SyncError::ApiClientError(msg)
                 })?;
 
@@ -153,6 +168,7 @@ impl Syncer {
                                 tracing::error!("Failed to forward error: {}", send_err);
                             }
                         }
+                        Self::forward(&ui_error, SyncTaskError::Other(msg.clone()));
                         SyncError::CacheError(msg)
                     })?;
                 total_synced += 1;
@@ -168,6 +184,7 @@ impl Syncer {
                         }
                     }
                 }
+                Self::forward(&ui_progress, SyncProgress::ItemSynced(total_synced));
             }
 
             tracing::info!("Synced {} media items so far.", total_synced);
@@ -197,6 +214,7 @@ impl Syncer {
                 }
             }
         }
+        Self::forward(&ui_progress, SyncProgress::Finished(total_synced));
         self.cache_manager
             .update_last_sync_async(Utc::now())
             .await
@@ -207,6 +225,7 @@ impl Syncer {
                         tracing::error!("Failed to forward error: {}", send_err);
                     }
                 }
+                Self::forward(&ui_error, SyncTaskError::Other(msg.clone()));
                 SyncError::CacheError(msg)
             })?;
         Ok(())
@@ -219,6 +238,8 @@ impl Syncer {
         progress_tx: mpsc::UnboundedSender<SyncProgress>,
         error_tx: mpsc::UnboundedSender<SyncTaskError>,
         status_tx: Option<mpsc::UnboundedSender<u32>>,
+        ui_progress_tx: Option<mpsc::UnboundedSender<SyncProgress>>,
+        ui_error_tx: Option<mpsc::UnboundedSender<SyncTaskError>>,
     ) -> (JoinHandle<Result<(), SyncTaskError>>, oneshot::Sender<()>) {
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
         let handle = spawn_local(async move {
@@ -237,10 +258,15 @@ impl Syncer {
                         tracing::info!("Periodic sync task shutting down");
                         return Ok(());
                     }
-                    _ = async {
+                    result = async {
                         if let Err(e) =
                             syncer
-                                .sync_media_items(Some(progress_tx.clone()), Some(error_tx.clone()))
+                                .sync_media_items(
+                                    Some(progress_tx.clone()),
+                                    Some(error_tx.clone()),
+                                    ui_progress_tx.clone(),
+                                    ui_error_tx.clone(),
+                                )
                                 .await
                         {
                             let code = match e {
@@ -260,6 +286,7 @@ impl Syncer {
                             {
                                 tracing::error!(error = ?send_err, "Failed to forward periodic sync error");
                             }
+                            Self::forward(&ui_error_tx, SyncTaskError::PeriodicSyncFailed(msg.clone()));
                             failures += 1;
                             if let Some(tx) = &status_tx {
                                 let _ = tx.send(failures);
@@ -268,6 +295,7 @@ impl Syncer {
                             if let Err(send_err) = error_tx.send(SyncTaskError::RestartAttempt(failures)) {
                                 tracing::error!(error = ?send_err, "Failed to forward restart attempt");
                             }
+                            Self::forward(&ui_error_tx, SyncTaskError::RestartAttempt(failures));
                             if failures > 3 {
                                 tracing::error!(?e, attempts = failures, backoff = wait, "Periodic sync failed");
                             } else {
@@ -281,10 +309,12 @@ impl Syncer {
                                     send_err
                                 )));
                             }
+                            Self::forward(&ui_progress_tx, SyncProgress::Retrying(wait));
                             if failures >= MAX_FAILURES {
                                 let abort_msg = format!("periodic sync aborted after {} failures", failures);
                                 tracing::error!("{}", abort_msg);
                                 let _ = error_tx.send(SyncTaskError::Aborted(abort_msg.clone()));
+                                Self::forward(&ui_error_tx, SyncTaskError::Aborted(abort_msg.clone()));
                                 return Err(SyncTaskError::Aborted(abort_msg));
                             }
                             sleep(Duration::from_secs(wait)).await;
@@ -297,7 +327,11 @@ impl Syncer {
                             }
                             sleep(interval).await;
                         }
-                    } => {}
+                        Ok::<(), SyncTaskError>(())
+                    } => match result {
+                        Ok(()) => {},
+                        Err(e) => return Err(e),
+                    }
                 }
             }
         });
@@ -305,9 +339,10 @@ impl Syncer {
     }
 
     #[cfg_attr(feature = "trace-spans", tracing::instrument)]
-    pub fn start_token_refresh_task(
+pub fn start_token_refresh_task(
         interval: Duration,
         error_tx: mpsc::UnboundedSender<SyncTaskError>,
+        ui_error_tx: Option<mpsc::UnboundedSender<SyncTaskError>>,
     ) -> (JoinHandle<Result<(), SyncTaskError>>, oneshot::Sender<()>) {
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
         let handle = spawn_local(async move {
@@ -320,7 +355,7 @@ impl Syncer {
                         tracing::info!("Token refresh task shutting down");
                         return Ok(());
                     }
-                    _ = async {
+                    result = async {
                         sleep(interval).await;
                         if let Err(e) = ensure_access_token_valid().await {
                             let code = match &e {
@@ -340,21 +375,28 @@ impl Syncer {
                             {
                                 tracing::error!(error = ?send_err, "Failed to forward token refresh error");
                             }
+                            Self::forward(&ui_error_tx, SyncTaskError::TokenRefreshFailed(msg.clone()));
                             failures += 1;
                             if let Err(send_err) = error_tx.send(SyncTaskError::RestartAttempt(failures)) {
                                 tracing::error!(error = ?send_err, "Failed to forward restart attempt");
                             }
+                            Self::forward(&ui_error_tx, SyncTaskError::RestartAttempt(failures));
                             if failures >= MAX_FAILURES {
                                 let abort_msg = format!("token refresh aborted after {} failures", failures);
                                 tracing::error!("{}", abort_msg);
                                 let _ = error_tx.send(SyncTaskError::Aborted(abort_msg.clone()));
+                                Self::forward(&ui_error_tx, SyncTaskError::Aborted(abort_msg.clone()));
                                 return Err(SyncTaskError::Aborted(abort_msg));
                             }
                         } else {
                             last_success = Utc::now();
                             failures = 0;
                         }
-                    } => {}
+                        Ok::<(), SyncTaskError>(())
+                    } => match result {
+                        Ok(()) => {},
+                        Err(e) => return Err(e),
+                    }
                 }
             }
         });
@@ -392,7 +434,7 @@ mod tests {
         let db_path = temp_file.path();
 
         let mut syncer = Syncer::new(db_path).await.expect("Failed to create syncer");
-        let result = syncer.sync_media_items(None, None).await;
+        let result = syncer.sync_media_items(None, None, None, None).await;
         assert!(result.is_ok(), "Synchronization failed: {:?}", result.err());
 
         let all_cached_items = syncer

--- a/sync/tests/abort_restart.rs
+++ b/sync/tests/abort_restart.rs
@@ -1,0 +1,63 @@
+use sync::{Syncer, SyncProgress, SyncTaskError};
+use serial_test::serial;
+use tempfile::NamedTempFile;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration, pause, advance};
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_periodic_sync_abort_and_restart() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_ACCESS_TOKEN", "token");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "refresh");
+    // first build syncer with mock to create db
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    let file = NamedTempFile::new().unwrap();
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let mut syncer = Syncer::new(file.path()).await.unwrap();
+            // drop mock to force failures
+            std::env::remove_var("MOCK_API_CLIENT");
+            let (p_tx, _p_rx) = mpsc::unbounded_channel();
+            let (e_tx, mut e_rx) = mpsc::unbounded_channel::<SyncTaskError>();
+            pause();
+            let (handle, _shutdown) = syncer.start_periodic_sync(
+                Duration::from_secs(1),
+                p_tx,
+                e_tx,
+                None,
+                None,
+                None,
+            );
+            advance(Duration::from_secs(40)).await; // enough for 5 failures
+            let result = handle.await.unwrap();
+            assert!(matches!(result, Err(SyncTaskError::Aborted(_))));
+            // ensure Aborted sent
+            let err = timeout(Duration::from_secs(5), e_rx.recv()).await.unwrap().unwrap();
+            assert!(matches!(err, SyncTaskError::Aborted(_)));
+            // restart with working API
+            std::env::set_var("MOCK_API_CLIENT", "1");
+            let mut syncer2 = Syncer::new(file.path()).await.unwrap();
+            let (p_tx2, mut p_rx2) = mpsc::unbounded_channel();
+            let (e_tx2, _e_rx2) = mpsc::unbounded_channel();
+            let (handle2, shutdown2) = syncer2.start_periodic_sync(
+                Duration::from_secs(1),
+                p_tx2,
+                e_tx2,
+                None,
+                None,
+                None,
+            );
+            advance(Duration::from_secs(1)).await;
+            let started = timeout(Duration::from_secs(5), p_rx2.recv()).await.unwrap();
+            assert!(matches!(started, Some(SyncProgress::Started)));
+            let _ = shutdown2.send(());
+            let _ = handle2.await;
+        })
+        .await;
+    std::env::remove_var("MOCK_KEYRING");
+    std::env::remove_var("MOCK_ACCESS_TOKEN");
+    std::env::remove_var("MOCK_REFRESH_TOKEN");
+    std::env::remove_var("MOCK_API_CLIENT");
+}

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -21,7 +21,7 @@ async fn test_periodic_sync_reports_error() {
             std::env::remove_var("MOCK_API_CLIENT");
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
-            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None);
+            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None);
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));
             let retry = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
@@ -66,7 +66,7 @@ async fn test_periodic_sync_progress_send_failure_forwarded() {
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
             let (handle, shutdown) =
-                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None);
+                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None);
             // consume the Started event then drop receiver to cause send failure later
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));

--- a/sync/tests/repeated_failures.rs
+++ b/sync/tests/repeated_failures.rs
@@ -27,6 +27,8 @@ async fn test_periodic_sync_repeated_failures_reported() {
                 prog_tx,
                 err_tx,
                 Some(status_tx),
+                None,
+                None,
             );
             let first = timeout(Duration::from_secs(5), status_rx.recv()).await.unwrap().unwrap();
             let second = timeout(Duration::from_secs(5), status_rx.recv()).await.unwrap().unwrap();

--- a/sync/tests/sync_flow.rs
+++ b/sync/tests/sync_flow.rs
@@ -14,7 +14,10 @@ async fn test_sync_flow_mock() {
     let file = NamedTempFile::new().unwrap();
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut syncer = Syncer::new(file.path()).await.unwrap();
-    syncer.sync_media_items(Some(tx), None).await.unwrap();
+    syncer
+        .sync_media_items(Some(tx), None, None, None)
+        .await
+        .unwrap();
     match rx.recv().await {
         Some(sync::SyncProgress::Started) => {}
         other => panic!("expected Started progress, got {:?}", other),

--- a/sync/tests/sync_media_items_error.rs
+++ b/sync/tests/sync_media_items_error.rs
@@ -19,7 +19,7 @@ async fn test_sync_media_items_reports_error() {
     let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
     let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
     let result = syncer
-        .sync_media_items(Some(prog_tx), Some(err_tx))
+        .sync_media_items(Some(prog_tx), Some(err_tx), None, None)
         .await;
     assert!(result.is_err());
     // ensure error forwarded

--- a/sync/tests/token_refresh_task.rs
+++ b/sync/tests/token_refresh_task.rs
@@ -16,7 +16,7 @@ async fn test_token_refresh_task_reports_error() {
     local
         .run_until(async {
             let (handle, shutdown) =
-                Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx);
+                Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx, None);
             let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
             assert!(err.is_some());
             let _ = shutdown.send(());
@@ -40,7 +40,7 @@ fn test_token_refresh_error_forwarded_to_ui() {
         local
             .run_until(async move {
                 let (handle, shutdown) =
-                    Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx);
+                    Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx, None);
                 let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap().unwrap();
                 let _ = shutdown.send(());
                 let _ = handle.await;


### PR DESCRIPTION
## Summary
- forward sync progress and error events to optional UI channels
- propagate results from periodic sync and token refresh tasks
- adjust call sites and update tests
- add integration test simulating sync abort and restart

## Testing
- `cargo check -p sync`
- `cargo test -p sync -- --nocapture` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68695c4f53dc8333b4eafcd83d3bff6b