### PR TITLE
Improve sync error reporting

### DIFF
--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 serial_test = "2"
-ui = { path = "../ui", default-features = false, features = ["no-gstreamer"] }
+ui = { path = "../ui", default-features = false }
 iced = { version = "0.12", features = ["wgpu", "tokio", "image"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -31,11 +31,11 @@ async fn test_periodic_sync_reports_error() {
             let detail_err = [err1, err2]
                 .into_iter()
                 .flatten()
-                .find(|e| matches!(e, SyncTaskError::PeriodicSyncFailed(_)))
+                .find(|e| matches!(e, SyncTaskError::PeriodicSyncFailed { .. }))
                 .expect("no periodic sync failure");
-            if let SyncTaskError::PeriodicSyncFailed(detail) = detail_err {
-                assert!(detail.contains("last_success"));
-                assert!(detail.contains("code:"));
+            if let SyncTaskError::PeriodicSyncFailed { message, code } = detail_err {
+                assert_eq!(code, sync::SyncErrorCode::Network);
+                assert!(message.contains("last_success"));
             } else {
                 panic!("unexpected error variant: {:?}", detail_err);
             }
@@ -77,11 +77,11 @@ async fn test_periodic_sync_progress_send_failure_forwarded() {
             let primary = [first, second]
                 .into_iter()
                 .flatten()
-                .find(|e| matches!(e, SyncTaskError::PeriodicSyncFailed(_)))
+                .find(|e| matches!(e, SyncTaskError::PeriodicSyncFailed { .. }))
                 .expect("no periodic failure");
-            if let SyncTaskError::PeriodicSyncFailed(msg) = &primary {
-                assert!(msg.contains("last_success"));
-                assert!(msg.contains("code:"));
+            if let SyncTaskError::PeriodicSyncFailed { message, code } = &primary {
+                assert_eq!(*code, sync::SyncErrorCode::Network);
+                assert!(message.contains("last_success"));
             }
             let _ = shutdown.send(());
             let _ = handle.await;

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -530,14 +530,6 @@ impl Application for GooglePiczUI {
             #[cfg(feature = "gstreamer")]
             Message::PlayVideo(item) => {
                 let url = format!("{}=dv", item.base_url);
-                if let Ok(mut player) = GstreamerIcedBase::new_url(&url::Url::parse(&url).unwrap(), false) {
-                    let _ = player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
-                    self.state = ViewState::PlayingVideo(player);
-                } else {
-                    let msg = "Failed to start video".to_string();
-                    self.errors.push(msg.clone());
-                    self.log_error(&msg);
-                    return GooglePiczUI::error_timeout();
                 match GstreamerIcedBase::new_url(&url::Url::parse(&url).unwrap(), false) {
                     Ok(mut player) => {
                         player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
@@ -590,10 +582,10 @@ impl Application for GooglePiczUI {
             Message::SyncError(err_msg) => {
                 tracing::error!("Sync error: {}", err_msg);
                 let detail = match &err_msg {
-                    SyncTaskError::TokenRefreshFailed(msg)
-                    | SyncTaskError::PeriodicSyncFailed(msg)
-                    | SyncTaskError::Other(msg)
-                    | SyncTaskError::Aborted(msg) => msg.clone(),
+                    SyncTaskError::TokenRefreshFailed { message, .. }
+                    | SyncTaskError::PeriodicSyncFailed { message, .. }
+                    | SyncTaskError::Other { message, .. }
+                    | SyncTaskError::Aborted(message) => message.clone(),
                     SyncTaskError::RestartAttempt(attempt) => format!("Restart attempt {attempt}"),
                 };
                 if let Some(idx) = detail.find("last_success:") {

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -1,5 +1,5 @@
 use ui::{GooglePiczUI, Message, SearchMode};
-use sync::SyncTaskError;
+use sync::{SyncTaskError, SyncErrorCode};
 use iced::Application;
 use tempfile::tempdir;
 use api_client::{MediaItem, MediaMetadata};
@@ -60,7 +60,10 @@ fn test_dismiss_error() {
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
     let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
-    let _ = ui.update(Message::SyncError(SyncTaskError::Other("err".into())));
+    let _ = ui.update(Message::SyncError(SyncTaskError::Other {
+        code: SyncErrorCode::Other,
+        message: "err".into(),
+    }));
     assert_eq!(ui.error_count(), 1);
     let _ = ui.update(Message::DismissError(0));
     assert_eq!(ui.error_count(), 0);
@@ -74,7 +77,10 @@ fn test_sync_error_added() {
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
     let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
-    let _ = ui.update(Message::SyncError(SyncTaskError::Other("boom".into())));
+    let _ = ui.update(Message::SyncError(SyncTaskError::Other {
+        code: SyncErrorCode::Other,
+        message: "boom".into(),
+    }));
     assert!(ui.error_count() > 0);
 }
 


### PR DESCRIPTION
## Summary
- provide `SyncErrorCode` enum with structured error variants
- log sync errors in CLI with new error channel
- handle new error variants in UI and tests
- ensure repeated failure tests check for new errors

## Testing
- `cargo check -p sync`
- `cargo check -p ui --no-default-features`
- `cargo test -p sync` *(fails: test repeated_failures, abort_restart due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6869831464988333a9ce8e9b05d12183