### PR TITLE
Add missing CLI failure tests

### DIFF
--- a/app/tests/sync_cli_subcommands.rs
+++ b/app/tests/sync_cli_subcommands.rs
@@ -64,3 +64,21 @@ fn sync_cli_cache_stats_no_cache() {
         .success()
         .stdout(contains("No cache found"));
 }
+
+#[test]
+fn sync_cli_rename_album_no_cache() {
+    build_cmd()
+        .args(&["rename-album", "1", "NewTitle"])
+        .assert()
+        .success()
+        .stdout(contains("No cache found"));
+}
+
+#[test]
+fn sync_cli_add_to_album_no_cache() {
+    build_cmd()
+        .args(&["add-to-album", "1", "2"])
+        .assert()
+        .success()
+        .stdout(contains("No cache found"));
+}


### PR DESCRIPTION
## Summary
- cover `rename-album` and `add-to-album` when no cache is present

## Testing
- `cargo test --all` *(fails: failed to select a version for `ui`)*
- `cargo test -p packaging` *(fails: failed to select a version for `ui`)*

------
https://chatgpt.com/codex/tasks/task_e_68698315c86c8333bf62dbbea7b92827