### PR TITLE
Improve packaging options and release automation

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -54,16 +54,31 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: googlepicz-linux
-          path: GooglePicz-*.deb
+          path: GooglePicz-*.*
+      - name: Release Linux artifact
+        if: runner.os == 'Linux' && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: GooglePicz-*.*
       - name: Upload macOS artifact
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: googlepicz-macos
           path: target/release/GooglePicz-*.dmg
+      - name: Release macOS artifact
+        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/release/GooglePicz-*.dmg
       - name: Upload Windows artifact
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: googlepicz-windows
           path: target/windows/GooglePicz-*-Setup.exe
+      - name: Release Windows artifact
+        if: runner.os == 'Windows' && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/windows/GooglePicz-*-Setup.exe

--- a/packaging/src/utils.rs
+++ b/packaging/src/utils.rs
@@ -73,7 +73,12 @@ pub fn verify_artifact_names() -> Result<(), PackagingError> {
     let version = workspace_version()?;
 
     if cfg!(target_os = "linux") {
-        let path = root.join(format!("GooglePicz-{}.deb", version));
+        let format = std::env::var("LINUX_PACKAGE_FORMAT").unwrap_or_else(|_| "deb".into());
+        let path = match format.as_str() {
+            "rpm" => root.join(format!("GooglePicz-{}.rpm", version)),
+            "appimage" => root.join(format!("GooglePicz-{}.AppImage", version)),
+            _ => root.join(format!("GooglePicz-{}.deb", version)),
+        };
         if !path.exists() {
             return Err(PackagingError::Other(format!("Missing artifact: {:?}", path)));
         }
@@ -99,7 +104,12 @@ pub fn write_checksums() -> Result<(), PackagingError> {
 
     let mut artifacts = Vec::new();
     if cfg!(target_os = "linux") {
-        artifacts.push(root.join(format!("GooglePicz-{}.deb", version)));
+        let format = std::env::var("LINUX_PACKAGE_FORMAT").unwrap_or_else(|_| "deb".into());
+        artifacts.push(match format.as_str() {
+            "rpm" => root.join(format!("GooglePicz-{}.rpm", version)),
+            "appimage" => root.join(format!("GooglePicz-{}.AppImage", version)),
+            _ => root.join(format!("GooglePicz-{}.deb", version)),
+        });
     } else if cfg!(target_os = "macos") {
         artifacts.push(root.join(format!("target/release/GooglePicz-{}.dmg", version)));
     } else if cfg!(target_os = "windows") {

--- a/packaging/tests/package_all.rs
+++ b/packaging/tests/package_all.rs
@@ -14,9 +14,20 @@ fn test_package_all_mock() {
     let root = get_project_root();
 
     if cfg!(target_os = "linux") {
-        let deb_dir = root.join("target/debian");
-        fs::create_dir_all(&deb_dir).unwrap();
-        fs::write(deb_dir.join("dummy.deb"), b"test").unwrap();
+        let format = std::env::var("LINUX_PACKAGE_FORMAT").unwrap_or_else(|_| "deb".into());
+        if format == "rpm" {
+            let rpm_dir = root.join("target/rpmbuild/RPMS");
+            fs::create_dir_all(&rpm_dir).unwrap();
+            fs::write(rpm_dir.join("dummy.rpm"), b"test").unwrap();
+        } else if format == "appimage" {
+            let img_dir = root.join("target/appimage");
+            fs::create_dir_all(&img_dir).unwrap();
+            fs::write(img_dir.join("dummy.AppImage"), b"test").unwrap();
+        } else {
+            let deb_dir = root.join("target/debian");
+            fs::create_dir_all(&deb_dir).unwrap();
+            fs::write(deb_dir.join("dummy.deb"), b"test").unwrap();
+        }
     }
 
     if cfg!(target_os = "macos") {
@@ -37,9 +48,14 @@ fn test_package_all_mock() {
 
     if cfg!(target_os = "linux") {
         let version = workspace_version().unwrap();
-        let deb_file = root.join(format!("GooglePicz-{}.deb", version));
-        assert!(deb_file.exists(), "Expected {:?} to exist", deb_file);
-        fs::remove_file(deb_file).unwrap();
+        let format = std::env::var("LINUX_PACKAGE_FORMAT").unwrap_or_else(|_| "deb".into());
+        let file = match format.as_str() {
+            "rpm" => root.join(format!("GooglePicz-{}.rpm", version)),
+            "appimage" => root.join(format!("GooglePicz-{}.AppImage", version)),
+            _ => root.join(format!("GooglePicz-{}.deb", version)),
+        };
+        assert!(file.exists(), "Expected {:?} to exist", file);
+        fs::remove_file(file).unwrap();
     }
 
     if cfg!(target_os = "macos") {


### PR DESCRIPTION
## Summary
- expand RELEASE_ARTIFACTS with a step-by-step setup guide and add rpm/AppImage info
- support rpm and AppImage output in the packager and tests
- publish build artifacts from `packager.yml` directly to GitHub releases

## Testing
- `cargo test --all --quiet` *(fails: failed to select a version for `ui`)*
- `cargo check -p packaging` *(fails: failed to select a version for `ui`)*

------
https://chatgpt.com/codex/tasks/task_e_6869831602f88333befea51fd9ef1d62