### PR TITLE
Add settings dialog with persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,8 +1830,10 @@ dependencies = [
 name = "e2e"
 version = "0.1.0"
 dependencies = [
+ "api_client",
  "assert_cmd",
  "cache",
+ "gstreamer_iced",
  "tempfile",
  "tokio",
 ]
@@ -2566,10 +2568,12 @@ dependencies = [
  "console-subscriber",
  "dirs",
  "predicates 2.1.5",
+ "serde",
  "serde_json",
  "sync",
  "tempfile",
  "tokio",
+ "toml 0.5.11",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -6851,11 +6855,13 @@ dependencies = [
  "httpmock",
  "iced",
  "reqwest",
+ "serde",
  "serial_test",
  "sync",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "toml 0.5.11",
  "tracing",
  "wgpu",
 ]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -19,6 +19,8 @@ tracing-appender = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
 clap = { workspace = true }
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+toml = "0.5"
 
 [build-dependencies]
 cargo-bundle-licenses = "0.4"

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
+use serde::{Serialize, Deserialize};
 
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AppConfig {
     pub log_level: String,
     pub oauth_redirect_port: u16,
@@ -80,5 +82,21 @@ impl AppConfig {
             self.trace_spans = true;
         }
         self
+    }
+
+    pub fn save_to(&self, path: Option<PathBuf>) -> std::io::Result<()> {
+        let path = match path {
+            Some(p) => p,
+            None => dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".googlepicz")
+                .join("config"),
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let data = toml::to_string(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        std::fs::write(path, data)
     }
 }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -18,6 +18,8 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 futures = "0.3"
 gstreamer_iced = { version = "0.1", optional = true }
+serde = { version = "1", features = ["derive"] }
+toml = "0.5"
 
 [dev-dependencies]
 httpmock = "0.6"
@@ -27,5 +29,6 @@ serial_test = "2"
 [features]
 trace-spans = []
 gstreamer = ["gstreamer_iced"]
+no-gstreamer = []
 default = ["gstreamer"]
 

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1,10 +1,13 @@
 //! User Interface module for GooglePicz.
 
 mod image_loader;
+#[path = "../app/src/config.rs"]
+mod app_config;
 
 pub use image_loader::{ImageLoader, ImageLoaderError};
 
 use api_client::{Album, ApiClient, MediaItem};
+use app_config::AppConfig;
 use auth;
 use cache::CacheManager;
 use chrono::{DateTime, Utc};
@@ -120,6 +123,9 @@ pub enum Message {
     ClearErrors,
     ShowSettings,
     CloseSettings,
+    SettingsLogLevelChanged(String),
+    SettingsCachePathChanged(String),
+    SaveSettings,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -213,6 +219,9 @@ pub struct GooglePiczUI {
     search_query: String,
     error_log_path: PathBuf,
     settings_open: bool,
+    config_path: PathBuf,
+    settings_log_level: String,
+    settings_cache_path: String,
 }
 
 impl GooglePiczUI {
@@ -257,6 +266,14 @@ impl GooglePiczUI {
     pub fn settings_open(&self) -> bool {
         self.settings_open
     }
+
+    pub fn settings_log_level(&self) -> String {
+        self.settings_log_level.clone()
+    }
+
+    pub fn settings_cache_path(&self) -> String {
+        self.settings_cache_path.clone()
+    }
     fn log_error(&self, msg: &str) {
         if let Ok(mut file) = std::fs::OpenOptions::new()
             .create(true)
@@ -293,6 +310,7 @@ impl Application for GooglePiczUI {
         let mut init_errors = Vec::new();
         let error_log_path = cache_dir.join("ui_errors.log");
         let cache_path = cache_dir.join("cache.sqlite");
+        let config_path = cache_dir.join("config");
 
         let cache_manager = match CacheManager::new(&cache_path) {
             Ok(cm) => Some(Arc::new(Mutex::new(cm))),
@@ -327,6 +345,7 @@ impl Application for GooglePiczUI {
             None => "Never synced".to_string(),
         };
 
+        let cfg = AppConfig::load_from(Some(config_path.clone()));
         let app = Self {
             photos: Vec::new(),
             albums: Vec::new(),
@@ -355,6 +374,9 @@ impl Application for GooglePiczUI {
             search_query: String::new(),
             error_log_path,
             settings_open: false,
+            config_path,
+            settings_log_level: cfg.log_level.clone(),
+            settings_cache_path: cfg.cache_path.to_string_lossy().to_string(),
         };
 
         (
@@ -620,8 +642,29 @@ impl Application for GooglePiczUI {
             }
             Message::ShowSettings => {
                 self.settings_open = true;
+                let cfg = AppConfig::load_from(Some(self.config_path.clone()));
+                self.settings_log_level = cfg.log_level;
+                self.settings_cache_path = cfg.cache_path.to_string_lossy().to_string();
             }
             Message::CloseSettings => {
+                self.settings_open = false;
+            }
+            Message::SettingsLogLevelChanged(val) => {
+                self.settings_log_level = val;
+            }
+            Message::SettingsCachePathChanged(val) => {
+                self.settings_cache_path = val;
+            }
+            Message::SaveSettings => {
+                let mut cfg = AppConfig::load_from(Some(self.config_path.clone()));
+                cfg.log_level = self.settings_log_level.clone();
+                cfg.cache_path = PathBuf::from(self.settings_cache_path.clone());
+                if let Err(e) = cfg.save_to(Some(self.config_path.clone())) {
+                    let msg = format!("Failed to save settings: {}", e);
+                    self.errors.push(msg.clone());
+                    self.log_error(&msg);
+                    return GooglePiczUI::error_timeout();
+                }
                 self.settings_open = false;
             }
             Message::ShowCreateAlbumDialog => {
@@ -1007,7 +1050,15 @@ impl Application for GooglePiczUI {
             Some(
                 column![
                     text("Settings").size(16),
-                    button("Close").on_press(Message::CloseSettings)
+                    text_input("Log level", &self.settings_log_level)
+                        .on_input(Message::SettingsLogLevelChanged),
+                    text_input("Cache path", &self.settings_cache_path)
+                        .on_input(Message::SettingsCachePathChanged),
+                    row![
+                        button("Save").on_press(Message::SaveSettings),
+                        button("Cancel").on_press(Message::CloseSettings)
+                    ]
+                    .spacing(10)
                 ]
                 .spacing(10),
             )

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -1,7 +1,11 @@
+#[path = "../../app/src/config.rs"]
+mod app_config;
+use app_config::AppConfig;
 use ui::{GooglePiczUI, Message, SearchMode};
 use sync::SyncTaskError;
 use iced::Application;
 use tempfile::tempdir;
+use std::path::PathBuf;
 use api_client::{MediaItem, MediaMetadata};
 use serial_test::serial;
 
@@ -152,5 +156,37 @@ fn test_settings_dialog() {
     let _ = ui.update(Message::ShowSettings);
     assert!(ui.settings_open());
     let _ = ui.update(Message::CloseSettings);
+    assert!(!ui.settings_open());
+}
+
+#[test]
+#[serial]
+fn test_save_settings() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    let gp_dir = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&gp_dir).unwrap();
+    let cfg = AppConfig {
+        log_level: "info".into(),
+        oauth_redirect_port: 8080,
+        thumbnails_preload: 20,
+        sync_interval_minutes: 5,
+        debug_console: false,
+        trace_spans: false,
+        cache_path: gp_dir.clone(),
+    };
+    cfg.save_to(Some(gp_dir.join("config"))).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, gp_dir.clone()));
+    let _ = ui.update(Message::ShowSettings);
+    ui.update(Message::SettingsLogLevelChanged("debug".into()));
+    let new_cache = gp_dir.join("new_cache");
+    let new_cache_str = new_cache.to_string_lossy().to_string();
+    ui.update(Message::SettingsCachePathChanged(new_cache_str.clone()));
+    let _ = ui.update(Message::SaveSettings);
+
+    let saved = AppConfig::load_from(Some(gp_dir.join("config")));
+    assert_eq!(saved.log_level, "debug");
+    assert_eq!(saved.cache_path, PathBuf::from(new_cache_str));
     assert!(!ui.settings_open());
 }


### PR DESCRIPTION
## Summary
- enhance UI with settings dialog (log level & cache path)
- add persistence via `AppConfig`
- unit tests for saving settings
- add serde/toml deps and save support

## Testing
- `cargo test -p ui --no-default-features --features no-gstreamer` *(fails: mismatched closing delimiter)*
- `cargo test` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698316c3b083339d6c8458f3ddcc28