### PR TITLE
Add e2e flow test and fix build

### DIFF
--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 serial_test = "2"
-ui = { path = "../ui", default-features = false, features = ["no-gstreamer"] }
+ui = { path = "../ui", default-features = false }
 iced = { version = "0.12", features = ["wgpu", "tokio", "image"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -332,7 +332,6 @@ impl Syncer {
                         Ok(()) => {},
                         Err(e) => return Err(e),
                     }
-                    } => {}
                 }
             }
             #[allow(unreachable_code)]
@@ -400,7 +399,6 @@ pub fn start_token_refresh_task(
                         Ok(()) => {},
                         Err(e) => return Err(e),
                     }
-                    } => {}
 
           }
             }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -10,6 +10,9 @@ tempfile = "3"
 cache = { path = "../../cache" }
 api_client = { path = "../../api_client" }
 gstreamer_iced = "0.1"
+auth = { path = "../../auth" }
+sync = { path = "../../sync", default-features = false }
+ui = { path = "../../ui", default-features = false }
 
 [[test]]
 name = "album_e2e"
@@ -29,3 +32,8 @@ harness = false
 [[test]]
 name = "video_playback"
 path = "tests/video_playback.rs"
+
+[[test]]
+name = "auth_sync_ui_e2e"
+path = "tests/auth_sync_ui_e2e.rs"
+harness = false

--- a/tests/e2e/tests/auth_sync_ui_e2e.rs
+++ b/tests/e2e/tests/auth_sync_ui_e2e.rs
@@ -1,0 +1,37 @@
+use tempfile::TempDir;
+use auth::authenticate;
+use sync::Syncer;
+use cache::CacheManager;
+use ui::{GooglePiczUI, Message};
+
+#[tokio::main]
+async fn main() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_ACCESS_TOKEN", "token");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "refresh");
+
+    let dir = TempDir::new().expect("dir");
+    std::env::set_var("HOME", dir.path());
+    let cache_dir = dir.path().join(".googlepicz");
+    std::fs::create_dir_all(&cache_dir).expect("cache dir");
+    let db_path = cache_dir.join("cache.sqlite");
+
+    authenticate(1).await.expect("auth");
+    let mut syncer = Syncer::new(&db_path).await.expect("syncer");
+    syncer
+        .sync_media_items(None, None, None, None)
+        .await
+        .expect("sync");
+    drop(syncer);
+
+    let cache = CacheManager::new(&db_path).expect("cache");
+    let items = cache.get_all_media_items().expect("items");
+    assert!(!items.is_empty());
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, cache_dir.clone()));
+    assert_eq!(ui.error_count(), 0);
+    let _ = ui.update(Message::PhotosLoaded(Ok(items)));
+    assert_eq!(ui.error_count(), 0);
+    assert!(ui.photo_count() > 0);
+}


### PR DESCRIPTION
## Summary
- add auth_sync_ui_e2e test to exercise auth, sync, cache and UI
- include auth/sync/ui crates in e2e test crate
- fix sync crate dev dependency
- clean up leftover code in sync::start_periodic_sync

## Testing
- `cargo check -p sync`
- `cargo test -p e2e` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869831736e4833385afd65102da1308