### PR TITLE
Add Linux build requirements doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Having trouble starting the application? Here are a few common issues:
 - **Developing without network access** – Set `MOCK_API_CLIENT=1` and `MOCK_KEYRING=1` (and optionally `MOCK_ACCESS_TOKEN`/`MOCK_REFRESH_TOKEN`) to run all tests without hitting Google APIs.
 - **Need more insight into async tasks?** – Set `debug_console = true` in `~/.googlepicz/config` or pass `--debug-console` to print detailed Tokio diagnostics.
 - **Profiling spans** – Set `trace_spans = true` or pass `--trace-spans` and build with `--features sync/trace-spans,ui/trace-spans` to record timing data.
-- **Missing system libraries on Linux** – Install `glib2.0-dev`, `gstreamer1.0-dev` and `libssl-dev` (or the equivalent packages for your distribution). On Debian/Ubuntu run:
+- **Missing system libraries on Linux** – Install `glib2.0-dev`, `gstreamer1.0-dev` and `libssl-dev` (or the equivalent packages for your distribution). See [docs/Todo-fuer-User.md](docs/Todo-fuer-User.md) for details. On Debian/Ubuntu run:
 
   ```bash
   sudo apt install glib2.0-dev gstreamer1.0-dev libssl-dev

--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -1,0 +1,19 @@
+# Linux Build Requirements
+
+Zum Kompilieren von GooglePicz werden unter Linux einige Entwicklungsbibliotheken benötigt. Installiere auf Debian/Ubuntu die folgenden Pakete:
+
+```bash
+sudo apt install glib2.0-dev gstreamer1.0-dev libssl-dev
+```
+
+Auf Fedora/RHEL heißen die Pakete:
+
+```bash
+sudo dnf install glib2-devel gstreamer1-devel openssl-devel
+```
+
+Wenn GStreamer nicht verfügbar ist oder die Video-Unterstützung nicht benötigt wird, kann das `ui`-Paket ohne die Standardfeatures gebaut werden:
+
+```bash
+cargo build -p ui --no-default-features
+```


### PR DESCRIPTION
## Summary
- add a short guide with Linux build dependencies and a command to build without GStreamer
- reference new doc from the troubleshooting section of the README

## Testing
- `cargo test` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68698cff169c8333810b7a71f6036a27