### PR TITLE
Add album assign photo e2e test

### DIFF
--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -27,5 +27,10 @@ path = "tests/search_e2e.rs"
 harness = false
 
 [[test]]
+name = "album_add_photo_e2e"
+path = "tests/album_add_photo_e2e.rs"
+harness = false
+
+[[test]]
 name = "video_playback"
 path = "video_playback.rs"

--- a/tests/e2e/tests/album_add_photo_e2e.rs
+++ b/tests/e2e/tests/album_add_photo_e2e.rs
@@ -1,0 +1,30 @@
+use api_client::ApiClient;
+use cache::CacheManager;
+use tempfile::TempDir;
+
+#[tokio::main]
+async fn main() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    std::env::set_var("MOCK_KEYRING", "1");
+
+    let dir = TempDir::new().expect("temp dir");
+    let db = dir.path().join("cache.sqlite");
+    let cache = CacheManager::new(&db).expect("cache");
+
+    let client = ApiClient::new("token".into());
+    let album = client.create_album("Holiday").await.expect("album");
+    cache.insert_album(&album).expect("insert album");
+
+    let (items, _) = client.list_media_items(1, None).await.expect("items");
+    let item = &items[0];
+    cache.insert_media_item(item).expect("insert item");
+
+    cache
+        .associate_media_item_with_album(&item.id, &album.id)
+        .expect("associate");
+
+    let stored = cache
+        .get_media_items_by_album(&album.id)
+        .expect("get items");
+    assert_eq!(stored.len(), 1);
+}


### PR DESCRIPTION
## Summary
- add `album_add_photo_e2e` scenario to create an album and assign a photo using mocks
- register the new scenario in `tests/e2e/Cargo.toml`

## Testing
- `cargo test -p e2e -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68698d02dd348333b7190f89f6435e64