### PR TITLE
Add new E2E face tagging scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,7 +1859,9 @@ version = "0.1.0"
 dependencies = [
  "api_client",
  "assert_cmd",
+ "base64 0.21.7",
  "cache",
+ "face_recognition",
  "gstreamer_iced",
  "tempfile",
  "tokio",

--- a/face_recognition/Cargo.toml
+++ b/face_recognition/Cargo.toml
@@ -8,7 +8,6 @@ api_client = { path = "../api_client" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 cache = { path = "../cache", optional = true }
-ui = { path = "../ui", optional = true }
 opencv = { version = "0.95", default-features = false, features = ["imgcodecs", "objdetect", "imgproc"] }
 reqwest = { version = "0.11", features = ["blocking"] }
 serde = { version = "1", features = ["derive"] }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -10,6 +10,8 @@ tempfile = "3"
 cache = { path = "../../cache" }
 api_client = { path = "../../api_client" }
 gstreamer_iced = "0.1"
+base64 = "0.21"
+face_recognition = { path = "../../face_recognition", features = ["cache"] }
 
 [[test]]
 name = "album_e2e"
@@ -34,3 +36,8 @@ harness = false
 [[test]]
 name = "video_playback"
 path = "video_playback.rs"
+
+[[test]]
+name = "face_tagging_e2e"
+path = "tests/face_tagging_e2e.rs"
+harness = false

--- a/tests/e2e/tests/face_tagging_e2e.rs
+++ b/tests/e2e/tests/face_tagging_e2e.rs
@@ -1,0 +1,47 @@
+use face_recognition::FaceRecognizer;
+use api_client::{MediaItem, MediaMetadata};
+use cache::CacheManager;
+use tempfile::TempDir;
+use base64::Engine;
+
+const SAMPLE_IMAGE_B64: &str = include_str!("../../face_recognition/tests/face_image.b64");
+
+#[tokio::main]
+async fn main() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    std::env::set_var("MOCK_KEYRING", "1");
+
+    let engine = base64::engine::general_purpose::STANDARD;
+    let data = engine.decode(SAMPLE_IMAGE_B64.replace('\n', "").as_bytes()).expect("decode");
+
+    let dir = TempDir::new().expect("dir");
+    let img_path = dir.path().join("face.jpg");
+    std::fs::write(&img_path, &data).expect("write image");
+    let db = dir.path().join("cache.sqlite");
+    let cache = CacheManager::new(&db).expect("cache");
+
+    let item = MediaItem {
+        id: "1".into(),
+        description: None,
+        product_url: String::new(),
+        base_url: format!("file://{}", img_path.display()),
+        mime_type: "image/jpeg".into(),
+        media_metadata: MediaMetadata {
+            creation_time: "2024-01-01T00:00:00Z".into(),
+            width: "200".into(),
+            height: "200".into(),
+            video: None,
+        },
+        filename: "face.jpg".into(),
+    };
+
+    cache.insert_media_item(&item).expect("insert item");
+    let recognizer = FaceRecognizer::new();
+    let faces = recognizer.detect_faces(&item).expect("detect faces");
+    recognizer
+        .assign_to_cache(&cache, &item, &faces)
+        .expect("assign");
+
+    let stored = cache.get_faces(&item.id).expect("faces").unwrap();
+    assert_eq!(stored.len(), faces.len());
+}

--- a/tests/e2e/video_playback.rs
+++ b/tests/e2e/video_playback.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 #[tokio::test]
 async fn test_sample_video_plays() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("videos")
         .join("sample.mp4");
@@ -14,6 +15,7 @@ async fn test_sample_video_plays() {
 
 #[tokio::test]
 async fn test_invalid_video_errors() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("videos")
         .join("invalid.mp4");


### PR DESCRIPTION
## Summary
- extend e2e test crate with face-tagging scenario
- update e2e crate dependencies
- set MOCK_API_CLIENT in video playback tests
- drop unused optional ui dependency from face_recognition

## Testing
- `cargo test --manifest-path tests/e2e/Cargo.toml --no-run` *(fails: unclosed delimiter in cache crate)*

------
https://chatgpt.com/codex/tasks/task_e_68699edf744c833391eecff75797fad5