### PR TITLE
Enable combined search filters

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -935,9 +935,6 @@ impl Application for GooglePiczUI {
                                 SearchMode::Description => cache
                                     .get_media_items_by_description(&query)
                                     .map_err(|e| e.to_string()),
-                                SearchMode::Text => cache
-                                    .get_media_items_by_text(&query)
-                                    .map_err(|e| e.to_string()),
                                 SearchMode::Favoriten => cache
                                     .get_media_items_by_favorite(true)
                                     .map_err(|e| e.to_string()),
@@ -953,6 +950,7 @@ impl Application for GooglePiczUI {
                                 SearchMode::CameraMake => cache
                                     .get_media_items_by_camera_make(&query)
                                     .map_err(|e| e.to_string()),
+                                SearchMode::Text => Vec::new(),
                             }?;
 
                             let start_dt = parse_single_date(&start, false);
@@ -963,12 +961,15 @@ impl Application for GooglePiczUI {
                                     start_dt,
                                     end_dt,
                                     if fav { Some(true) } else { None },
+                                    if mode == SearchMode::Text { Some(query) } else { None },
                                 )
                                 .await
                                 .map_err(|e| e.to_string())
                                 .map(|mut extra| {
-                                    // Intersect results with base
-                                    extra.retain(|i| base.iter().any(|b| b.id == i.id));
+                                    if mode != SearchMode::Text {
+                                        // Intersect results with base
+                                        extra.retain(|i| base.iter().any(|b| b.id == i.id));
+                                    }
                                     extra
                                 })
                         },


### PR DESCRIPTION
## Summary
- support text/date/favorite combination search in cache and UI
- add CLI flags for start/end and favorite
- extend cache and CLI tests accordingly

## Testing
- `cargo test --workspace --quiet` *(fails: cyclic package dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68699ede663883338cae35e6727c9282