### PR TITLE
Extend packaging tests & CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,73 @@ jobs:
         with:
           name: checksums-${{ runner.os }}
           path: checksums.txt
+
+  build-installers:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            format: deb
+          - os: ubuntu-latest
+            format: rpm
+          - os: ubuntu-latest
+            format: appimage
+          - os: macos-latest
+            format: dmg
+          - os: windows-latest
+            format: nsis
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install cargo tools (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cargo install cargo-deb
+          cargo install cargo-rpm
+          sudo apt-get update
+          sudo apt-get install -y appimagetool
+
+      - name: Install cargo-bundle
+        if: matrix.os == 'macos-latest'
+        run: cargo install cargo-bundle
+
+      - name: Install NSIS
+        if: matrix.os == 'windows-latest'
+        run: choco install nsis -y
+
+      - name: Build installer
+        run: cargo run --package packaging --bin packager
+        env:
+          LINUX_PACKAGE_FORMAT: ${{ matrix.format }}
+
+      - name: Verify artifacts
+        run: cargo run --package packaging --bin ci_checks
+
+      - name: Upload Linux artifact
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: googlepicz-linux-${{ matrix.format }}
+          path: GooglePicz-*.*
+
+      - name: Upload macOS artifact
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: googlepicz-macos
+          path: target/release/GooglePicz-*.dmg
+
+      - name: Upload Windows artifact
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: googlepicz-windows
+          path: target/windows/GooglePicz-*-Setup.exe

--- a/docs/RELEASE_ARTIFACTS.md
+++ b/docs/RELEASE_ARTIFACTS.md
@@ -127,3 +127,15 @@ Follow these steps to create and sign final release artifacts:
    `dpkg-sig --verify`). Check the console output for any errors.
 6. Upload the versioned artifacts from the `target` directory when creating the
    GitHub release.
+
+### Uploading the artifacts
+
+The generated installers can be attached to a GitHub release either via the web
+interface or using the `gh` CLI:
+
+```bash
+gh release upload <tag> target/release/GooglePicz-*.dmg GooglePicz-*.{deb,rpm,AppImage} target/windows/GooglePicz-*-Setup.exe
+```
+
+Replace `<tag>` with the version tag you are publishing. Drag‑and‑drop also
+works on the release page.

--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -545,4 +545,91 @@ mod tests {
         assert!(result.is_ok());
         std::env::remove_var("MOCK_COMMANDS");
     }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_macos_notarization_mock() {
+        use crate::utils::{verify_artifact_names, workspace_version};
+        std::env::set_var("MOCK_COMMANDS", "1");
+        std::env::set_var("MAC_SIGN_ID", "test");
+        std::env::set_var("APPLE_ID", "user@example.com");
+        std::env::set_var("APPLE_PASSWORD", "pw");
+        let root = get_project_root();
+        let release = root.join("target/release");
+        fs::create_dir_all(&release).unwrap();
+        fs::write(release.join("GooglePicz.dmg"), b"test").unwrap();
+
+        let result = create_installer();
+        assert!(result.is_ok());
+        verify_artifact_names().unwrap();
+
+        let version = workspace_version().unwrap();
+        let dmg = release.join(format!("GooglePicz-{}.dmg", version));
+        assert!(dmg.exists());
+        fs::remove_file(dmg).unwrap();
+
+        std::env::remove_var("MOCK_COMMANDS");
+        std::env::remove_var("MAC_SIGN_ID");
+        std::env::remove_var("APPLE_ID");
+        std::env::remove_var("APPLE_PASSWORD");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial]
+    fn test_linux_signing_mock() {
+        use crate::utils::{verify_artifact_names, workspace_version};
+        std::env::set_var("MOCK_COMMANDS", "1");
+        std::env::set_var("LINUX_SIGN_KEY", "DEADBEEF");
+        std::env::set_var("LINUX_PACKAGE_FORMAT", "deb");
+        let root = get_project_root();
+        let deb_dir = root.join("target/debian");
+        fs::create_dir_all(&deb_dir).unwrap();
+        fs::write(deb_dir.join("dummy.deb"), b"test").unwrap();
+
+        let result = create_installer();
+        assert!(result.is_ok());
+        verify_artifact_names().unwrap();
+
+        let version = workspace_version().unwrap();
+        let deb = root.join(format!("GooglePicz-{}.deb", version));
+        assert!(deb.exists());
+        fs::remove_file(deb).unwrap();
+
+        std::env::remove_var("MOCK_COMMANDS");
+        std::env::remove_var("LINUX_SIGN_KEY");
+        std::env::remove_var("LINUX_PACKAGE_FORMAT");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[serial]
+    fn test_windows_signing_mock() {
+        use crate::utils::{verify_artifact_names, workspace_version};
+        std::env::set_var("MOCK_COMMANDS", "1");
+        std::env::set_var("WINDOWS_CERT", "C:/dummy.pfx");
+        std::env::set_var("WINDOWS_CERT_PASSWORD", "pw");
+        let root = get_project_root();
+        let win_dir = root.join("target/windows");
+        fs::create_dir_all(&win_dir).unwrap();
+        let version = workspace_version().unwrap();
+        fs::write(win_dir.join(format!("GooglePicz-{}-Setup.exe", version)), b"test").unwrap();
+        let rel_dir = root.join("target/release");
+        fs::create_dir_all(&rel_dir).unwrap();
+        fs::write(rel_dir.join("googlepicz.exe"), b"test").unwrap();
+
+        let result = create_installer();
+        assert!(result.is_ok());
+        verify_artifact_names().unwrap();
+
+        let exe = win_dir.join(format!("GooglePicz-{}-Setup.exe", version));
+        assert!(exe.exists());
+        fs::remove_file(exe).unwrap();
+        fs::remove_file(rel_dir.join("googlepicz.exe")).unwrap();
+
+        std::env::remove_var("MOCK_COMMANDS");
+        std::env::remove_var("WINDOWS_CERT");
+        std::env::remove_var("WINDOWS_CERT_PASSWORD");
+    }
 }


### PR DESCRIPTION
## Summary
- build installers for Debian, RPM, AppImage, DMG and NSIS in CI
- verify artifact naming during CI installer build
- add tests for macOS notarisation and Linux/Windows signing flows
- document how to upload built artifacts

## Testing
- `cargo test -p packaging` *(fails: cyclic package dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68699edcbca883338f6b22ab93fad112