### PR TITLE
Add preload threading config and sync resume support

### DIFF
--- a/.github/actions/checks/action.yml
+++ b/.github/actions/checks/action.yml
@@ -11,3 +11,6 @@ runs:
     - name: Run tests
       run: cargo test --all
       shell: bash
+    - name: Run benchmarks
+      run: cargo bench --bench cache_bench -p cache -- --test
+      shell: bash

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -6,6 +6,7 @@ pub struct AppConfig {
     pub log_level: String,
     pub oauth_redirect_port: u16,
     pub thumbnails_preload: usize,
+    pub preload_threads: usize,
     pub sync_interval_minutes: u64,
     pub debug_console: bool,
     pub trace_spans: bool,
@@ -16,6 +17,7 @@ pub struct AppConfigOverrides {
     pub log_level: Option<String>,
     pub oauth_redirect_port: Option<u16>,
     pub thumbnails_preload: Option<usize>,
+    pub preload_threads: Option<usize>,
     pub sync_interval_minutes: Option<u64>,
     pub debug_console: bool,
     pub trace_spans: bool,
@@ -39,6 +41,7 @@ impl AppConfig {
             .unwrap_or_else(|_| "info".to_string());
         let oauth_redirect_port = cfg.get_int("oauth_redirect_port").unwrap_or(8080) as u16;
         let thumbnails_preload = cfg.get_int("thumbnails_preload").unwrap_or(20) as usize;
+        let preload_threads = cfg.get_int("preload_threads").unwrap_or(4) as usize;
         let sync_interval_minutes = cfg.get_int("sync_interval_minutes").unwrap_or(5) as u64;
         let debug_console = cfg.get_bool("debug_console").unwrap_or(false);
         let trace_spans = cfg.get_bool("trace_spans").unwrap_or(false);
@@ -55,6 +58,7 @@ impl AppConfig {
             log_level,
             oauth_redirect_port,
             thumbnails_preload,
+            preload_threads,
             sync_interval_minutes,
             debug_console,
             trace_spans,
@@ -71,6 +75,9 @@ impl AppConfig {
         }
         if let Some(t) = ov.thumbnails_preload {
             self.thumbnails_preload = t;
+        }
+        if let Some(pt) = ov.preload_threads {
+            self.preload_threads = pt;
         }
         if let Some(s) = ov.sync_interval_minutes {
             self.sync_interval_minutes = s;

--- a/cache/benches/cache_bench.rs
+++ b/cache/benches/cache_bench.rs
@@ -163,12 +163,49 @@ fn bench_camera_model_query(c: &mut Criterion) {
     });
 }
 
+fn bench_camera_make_query(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..10_000u32 {
+        let make = if i % 2 == 0 { "Canon" } else { "Nikon" };
+        let mut item = sample_media_item(&i.to_string());
+        item.media_metadata.video = Some(VideoMetadata {
+            camera_make: Some(make.into()),
+            camera_model: None,
+            fps: None,
+            status: None,
+        });
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("camera_make_query", |b| {
+        b.iter(|| {
+            let _ = cache.get_media_items_by_camera_make("Canon").unwrap();
+        })
+    });
+}
+
+fn bench_filename_query(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..10_000u32 {
+        let item = sample_media_item(&format!("file{}", i));
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("filename_query", |b| {
+        b.iter(|| {
+            let _ = cache.get_media_items_by_filename("file1").unwrap();
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_load_all,
     bench_load_all_10k,
     bench_load_all_100k,
     bench_camera_model_query,
+    bench_camera_make_query,
+    bench_filename_query,
     bench_mime_type_query,
     bench_album_query
 );

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -181,6 +181,10 @@ fn apply_migrations(conn: &mut Connection) -> Result<(), CacheError> {
              );\
              UPDATE schema_version SET version = 14;"
         ),
+        M::up(
+            "CREATE INDEX IF NOT EXISTS idx_media_metadata_camera_make ON media_metadata (camera_make);\
+             UPDATE schema_version SET version = 15;"
+        ),
     ]);
     migrations
         .to_latest(conn)
@@ -480,6 +484,7 @@ impl CacheManager {
     }
 
     pub fn get_media_items_by_camera_model(&self, model: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
+        let start = std::time::Instant::now();
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
@@ -523,10 +528,12 @@ impl CacheManager {
                 CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e))
             })?);
         }
+        tracing::info!("query_time_ms" = %start.elapsed().as_millis(), "query" = "camera_model", "count" = items.len());
         Ok(items)
     }
 
     pub fn get_media_items_by_camera_make(&self, make: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
+        let start = std::time::Instant::now();
         let conn = self.lock_conn()?;
         let mut stmt = conn
             .prepare(
@@ -570,10 +577,12 @@ impl CacheManager {
                 CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e))
             })?);
         }
+        tracing::info!("query_time_ms" = %start.elapsed().as_millis(), "query" = "camera_make", "count" = items.len());
         Ok(items)
     }
 
     pub fn get_media_items_by_filename(&self, pattern: &str) -> Result<Vec<api_client::MediaItem>, CacheError> {
+        let start = std::time::Instant::now();
         let like_pattern = format!("%{}%", pattern);
         let conn = self.lock_conn()?;
         let mut stmt = conn
@@ -618,6 +627,7 @@ impl CacheManager {
                 CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e))
             })?);
         }
+        tracing::info!("query_time_ms" = %start.elapsed().as_millis(), "query" = "filename", "count" = items.len());
         Ok(items)
     }
 

--- a/ui/tests/image_loader.rs
+++ b/ui/tests/image_loader.rs
@@ -12,7 +12,7 @@ async fn test_thumbnail_cached() {
     });
 
     let dir = tempdir().unwrap();
-    let loader = ImageLoader::new(dir.path().to_path_buf());
+    let loader = ImageLoader::new(dir.path().to_path_buf(), 4);
     let url = format!("{}/img.jpg", server.url(""));
 
     loader.load_thumbnail("1", &url).await.unwrap();
@@ -34,7 +34,7 @@ async fn test_full_image_cached() {
     });
 
     let dir = tempdir().unwrap();
-    let loader = ImageLoader::new(dir.path().to_path_buf());
+    let loader = ImageLoader::new(dir.path().to_path_buf(), 4);
     let url = format!("{}/img.jpg", server.url(""));
 
     loader.load_full_image("1", &url).await.unwrap();
@@ -59,7 +59,7 @@ async fn test_thumbnail_not_found() {
         .timeout(Duration::from_secs(1))
         .build()
         .unwrap();
-    let loader = ImageLoader::with_client(dir.path().to_path_buf(), client);
+    let loader = ImageLoader::with_client(dir.path().to_path_buf(), client, 4);
     let url = format!("{}/missing.jpg", server.url(""));
 
     let err = loader.load_thumbnail("1", &url).await.err().unwrap();
@@ -79,7 +79,7 @@ async fn test_thumbnail_timeout() {
         .timeout(Duration::from_millis(50))
         .build()
         .unwrap();
-    let loader = ImageLoader::with_client(dir.path().to_path_buf(), client);
+    let loader = ImageLoader::with_client(dir.path().to_path_buf(), client, 4);
     let url = format!("{}/slow.jpg", server.url(""));
 
     let err = loader.load_thumbnail("1", &url).await.err().unwrap();
@@ -93,7 +93,7 @@ async fn test_network_error() {
         .timeout(Duration::from_millis(100))
         .build()
         .unwrap();
-    let loader = ImageLoader::with_client(dir.path().to_path_buf(), client);
+    let loader = ImageLoader::with_client(dir.path().to_path_buf(), client, 4);
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -33,7 +33,7 @@ fn test_initial_state() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     assert_eq!(ui.photo_count(), 0);
     assert_eq!(ui.album_count(), 0);
     assert_eq!(ui.state_debug(), "Grid");
@@ -46,7 +46,7 @@ fn test_select_and_close_photo() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     let item = sample_item();
 
     let _ = ui.update(Message::SelectPhoto(item.clone()));
@@ -63,7 +63,7 @@ fn test_dismiss_error() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SyncError(SyncTaskError::Other {
         code: SyncErrorCode::Other,
         message: "err".into(),
@@ -80,7 +80,7 @@ fn test_sync_error_added() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SyncError(SyncTaskError::Other {
         code: SyncErrorCode::Other,
         message: "boom".into(),
@@ -95,7 +95,7 @@ fn test_rename_dialog_state() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::ShowRenameAlbumDialog("a1".into(), "Old".into()));
     assert_eq!(ui.renaming_album(), Some("a1".into()));
     assert_eq!(ui.rename_album_title(), "Old");
@@ -110,7 +110,7 @@ fn test_delete_dialog_state() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::ShowDeleteAlbumDialog("a1".into()));
     assert_eq!(ui.deleting_album(), Some("a1".into()));
     let _ = ui.update(Message::CancelDeleteAlbum);
@@ -124,7 +124,7 @@ fn test_search_input() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SearchInputChanged("query".into()));
     assert_eq!(ui.search_query(), "query");
 }
@@ -136,7 +136,7 @@ fn test_search_mode() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     assert_eq!(ui.search_mode(), SearchMode::Filename);
     let _ = ui.update(Message::SearchModeChanged(SearchMode::Favoriten));
     assert_eq!(ui.search_mode(), SearchMode::Favoriten);
@@ -157,7 +157,7 @@ fn test_settings_dialog() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     assert!(!ui.settings_open());
     let _ = ui.update(Message::ShowSettings);
     assert!(ui.settings_open());
@@ -183,7 +183,7 @@ fn test_save_settings() {
     };
     cfg.save_to(Some(gp_dir.join("config"))).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, gp_dir.clone()));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, gp_dir.clone()));
     let _ = ui.update(Message::ShowSettings);
     ui.update(Message::SettingsLogLevelChanged("debug".into()));
     let new_cache = gp_dir.join("new_cache");
@@ -204,7 +204,7 @@ fn test_faces_loaded_and_rename() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
     let item = sample_item();
 
     let _ = ui.update(Message::SelectPhoto(item.clone()));


### PR DESCRIPTION
## Summary
- add configurable `preload_threads` to `AppConfig`
- apply dynamic concurrency in `ImageLoader`
- record frequently used query timings and add DB index for `camera_make`
- store sync state to resume after failures
- extend cache benchmarks and run them in CI

## Testing
- `cargo check` *(fails: cyclic package dependency)*
- `cargo test` *(fails: cyclic package dependency)*
- `cargo bench --bench cache_bench -p cache` *(fails: cyclic package dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68699ed9e2c0833395bd35b8e59a8736