### PR TITLE
Improve video download & cleanup

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -22,10 +22,10 @@ gstreamer_iced = { version = "0.1.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 rfd = "0.14"
+tempfile = "3"
 
 [dev-dependencies]
 httpmock = "0.6"
-tempfile = "3"
 serial_test = "2"
 
 [features]

--- a/ui/src/video_downloader.rs
+++ b/ui/src/video_downloader.rs
@@ -1,6 +1,7 @@
 use futures_util::StreamExt;
 use reqwest;
 use std::path::Path;
+use tempfile::{Builder, TempPath};
 use thiserror::Error;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
@@ -49,6 +50,34 @@ impl VideoDownloader {
         }
         Ok(())
     }
+
+    /// Download a video to a temporary file which is deleted when dropped.
+    pub async fn download_to_tempfile(
+        &self,
+        url: &str,
+        extension: &str,
+    ) -> Result<TempPath, VideoDownloadError> {
+        let mut file = Builder::new()
+            .suffix(extension)
+            .tempfile()
+            .map_err(|e| VideoDownloadError::Io(e.to_string()))?;
+
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| VideoDownloadError::Network(e.to_string()))?;
+        let mut stream = resp.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk.map_err(|e| VideoDownloadError::Network(e.to_string()))?;
+            file.as_file_mut()
+                .write_all(&bytes)
+                .await
+                .map_err(|e| VideoDownloadError::Io(e.to_string()))?;
+        }
+        Ok(file.into_temp_path())
+    }
 }
 
 #[cfg(test)]
@@ -72,6 +101,27 @@ mod tests {
             .unwrap();
         let content = tokio::fs::read(&path).await.unwrap();
         assert_eq!(content, b"video-data");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_download_to_tempfile() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/video.mp4");
+            then.status(200).body("video-data");
+        });
+        let dl = VideoDownloader::new();
+        let temp = dl
+            .download_to_tempfile(&format!("{}/video.mp4", server.url("")), ".mp4")
+            .await
+            .unwrap();
+        let content = tokio::fs::read(&temp).await.unwrap();
+        assert_eq!(content, b"video-data");
+        // temp file will be removed on drop
+        let path = temp.to_path_buf();
+        drop(temp);
+        assert!(!path.exists());
         mock.assert();
     }
 }


### PR DESCRIPTION
## Summary
- add new streaming `download_to_tempfile` to video_downloader
- use temporary file for gstreamer playback and clean up when closed
- surface video start errors
- move `tempfile` crate to runtime deps

## Testing
- `cargo test --workspace` *(fails: could not run clang build)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa71d1ac8333a789f93b80da1f36