### PR TITLE
Add packager tool checks and installer tests

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -17,3 +17,21 @@ Wenn GStreamer nicht verfügbar ist oder die Video-Unterstützung nicht benötig
 ```bash
 cargo build -p ui --no-default-features
 ```
+
+## Pakete für den Packager
+
+Zur Erstellung von Installern benötigt der Packager einige externe Tools. Stelle sicher, dass folgende Programme verfügbar sind:
+
+- `cargo-deb`, `cargo-bundle`, `cargo-bundle-licenses`, `cargo-rpm`
+  ```bash
+  cargo install cargo-deb cargo-bundle cargo-bundle-licenses cargo-rpm
+  ```
+- `appimagetool` und `dpkg-sig` (optional für Linux-Signing)
+  ```bash
+  sudo apt install appimagetool dpkg-sig   # Debian/Ubuntu
+  sudo dnf install appimagetool dpkg-sig   # Fedora/RHEL
+  ```
+- `makensis` (Windows) und `signtool` aus dem Windows SDK
+- `codesign`, `hdiutil` und `xcrun` auf macOS (Teil der Xcode Command Line Tools)
+
+Diese Programme müssen im `PATH` liegen, damit `cargo run --package packaging --bin packager` erfolgreich ist.

--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -78,6 +78,7 @@ fn verify_tools() -> Result<(), PackagingError> {
 
     for (cmd, msg) in tools {
         if !command_available(cmd) {
+            tracing::error!("{}", msg);
             return Err(PackagingError::MissingCommand(msg.into()));
         }
     }
@@ -97,17 +98,23 @@ fn run_command(cmd: &str, args: &[&str]) -> Result<(), PackagingError> {
             match *sub {
                 "deb" => {
                     if !command_available("cargo-deb") {
-                        return Err(PackagingError::MissingCommand(hint("cargo-deb", "cargo install cargo-deb")));
+                        let msg = hint("cargo-deb", "cargo install cargo-deb");
+                        tracing::error!("{}", msg);
+                        return Err(PackagingError::MissingCommand(msg));
                     }
                 }
                 "bundle" => {
                     if !command_available("cargo-bundle") {
-                        return Err(PackagingError::MissingCommand(hint("cargo-bundle", "cargo install cargo-bundle")));
+                        let msg = hint("cargo-bundle", "cargo install cargo-bundle");
+                        tracing::error!("{}", msg);
+                        return Err(PackagingError::MissingCommand(msg));
                     }
                 }
                 "bundle-licenses" => {
                     if !command_available("cargo-bundle-licenses") {
-                        return Err(PackagingError::MissingCommand(hint("cargo-bundle-licenses", "cargo install cargo-bundle-licenses")));
+                        let msg = hint("cargo-bundle-licenses", "cargo install cargo-bundle-licenses");
+                        tracing::error!("{}", msg);
+                        return Err(PackagingError::MissingCommand(msg));
                     }
                 }
                 _ => {}
@@ -121,6 +128,7 @@ fn run_command(cmd: &str, args: &[&str]) -> Result<(), PackagingError> {
             "dpkg-sig" => hint("dpkg-sig", "install dpkg-sig from your distribution"),
             _ => hint(cmd, &format!("install {cmd} and ensure it is in your PATH")),
         };
+        tracing::error!("{}", msg);
         return Err(PackagingError::MissingCommand(msg));
     }
 

--- a/packaging/tests/create_installer.rs
+++ b/packaging/tests/create_installer.rs
@@ -1,0 +1,83 @@
+use packaging::{create_installer};
+use packaging::utils::{get_project_root, workspace_version, verify_artifact_names};
+use serial_test::serial;
+use std::fs;
+
+#[cfg(target_os = "linux")]
+#[test]
+#[serial]
+fn test_create_installer_linux_mock() {
+    std::env::set_var("MOCK_COMMANDS", "1");
+    std::env::set_var("LINUX_PACKAGE_FORMAT", "deb");
+    let root = get_project_root();
+    let deb_dir = root.join("target/debian");
+    fs::create_dir_all(&deb_dir).unwrap();
+    fs::write(deb_dir.join("dummy.deb"), b"test").unwrap();
+
+    let result = create_installer();
+    assert!(result.is_ok());
+    verify_artifact_names().unwrap();
+
+    let version = workspace_version().unwrap();
+    let deb = root.join(format!("GooglePicz-{}.deb", version));
+    assert!(deb.exists());
+    fs::remove_file(deb).unwrap();
+
+    std::env::remove_var("MOCK_COMMANDS");
+    std::env::remove_var("LINUX_PACKAGE_FORMAT");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[serial]
+fn test_create_installer_macos_mock() {
+    std::env::set_var("MOCK_COMMANDS", "1");
+    std::env::set_var("MAC_SIGN_ID", "test");
+    let root = get_project_root();
+    let release_dir = root.join("target/release");
+    fs::create_dir_all(&release_dir).unwrap();
+    fs::write(release_dir.join("GooglePicz.dmg"), b"test").unwrap();
+
+    let result = create_installer();
+    assert!(result.is_ok());
+    verify_artifact_names().unwrap();
+
+    let version = workspace_version().unwrap();
+    let dmg = release_dir.join(format!("GooglePicz-{}.dmg", version));
+    assert!(dmg.exists());
+    fs::remove_file(dmg).unwrap();
+
+    std::env::remove_var("MOCK_COMMANDS");
+    std::env::remove_var("MAC_SIGN_ID");
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+#[serial]
+fn test_create_installer_windows_mock() {
+    std::env::set_var("MOCK_COMMANDS", "1");
+    std::env::set_var("WINDOWS_CERT", "C:/dummy.pfx");
+    std::env::set_var("WINDOWS_CERT_PASSWORD", "pw");
+    let root = get_project_root();
+    let win_dir = root.join("target/windows");
+    fs::create_dir_all(&win_dir).unwrap();
+    let version = workspace_version().unwrap();
+    fs::write(win_dir.join(format!("GooglePicz-{}-Setup.exe", version)), b"test").unwrap();
+    let rel_dir = root.join("target/release");
+    fs::create_dir_all(&rel_dir).unwrap();
+    fs::write(rel_dir.join("googlepicz.exe"), b"test").unwrap();
+
+    let result = create_installer();
+    assert!(result.is_ok());
+    verify_artifact_names().unwrap();
+
+    let exe = win_dir.join(format!("GooglePicz-{}-Setup.exe", version));
+    assert!(exe.exists());
+    fs::remove_file(exe).unwrap();
+    fs::remove_file(rel_dir.join("googlepicz.exe")).unwrap();
+
+    std::env::remove_var("MOCK_COMMANDS");
+    std::env::remove_var("WINDOWS_CERT");
+    std::env::remove_var("WINDOWS_CERT_PASSWORD");
+}
+


### PR DESCRIPTION
## Summary
- emit log errors when required external commands are missing
- add integration tests for `create_installer` on all platforms
- document extra tools required to run the packager

## Testing
- `cargo test -p packaging`

------
https://chatgpt.com/codex/tasks/task_e_6869aa749c248333b210ee987ac8f4cc