### PR TITLE
Consolidate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,7 @@ cargo run --package googlepicz
 cargo run --package googlepicz --bin sync_cli -- sync
 ```
 
-See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for optional settings via `AppConfig`.
-
-
-For available configuration options see [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
+See [docs/USER_GUIDE.md](docs/USER_GUIDE.md) for configuration options and example settings.
 
 ### Setting up OAuth Credentials
 
@@ -102,7 +99,7 @@ Having trouble starting the application? Here are a few common issues:
 - **Developing without network access** – Set `MOCK_API_CLIENT=1` and `MOCK_KEYRING=1` (and optionally `MOCK_ACCESS_TOKEN`/`MOCK_REFRESH_TOKEN`) to run all tests without hitting Google APIs.
 - **Need more insight into async tasks?** – Set `debug_console = true` in `~/.googlepicz/config` or pass `--debug-console` to print detailed Tokio diagnostics.
 - **Profiling spans** – Set `trace_spans = true` or pass `--trace-spans` and build with `--features sync/trace-spans,ui/trace-spans` to record timing data.
-- **Missing system libraries on Linux** – Install `glib2.0-dev`, `gstreamer1.0-dev` and `libssl-dev` (or the equivalent packages for your distribution). See [docs/Todo-fuer-User.md](docs/Todo-fuer-User.md) for details. On Debian/Ubuntu run:
+- **Missing system libraries on Linux** – Install `glib2.0-dev`, `gstreamer1.0-dev` and `libssl-dev` (or the equivalent packages for your distribution). See [docs/USER_GUIDE.md](docs/USER_GUIDE.md) for details. On Debian/Ubuntu run:
 
   ```bash
   sudo apt install glib2.0-dev gstreamer1.0-dev libssl-dev
@@ -138,11 +135,7 @@ GooglePicz/
 
 ## 📝 Documentation
 
-See the following documents for additional details:
-- [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md) – detailed technical documentation.
-- [Configuration Guide](docs/CONFIGURATION.md) – lists available `AppConfig` options.
-- Command line flags (e.g. `--log-level debug`) can override config values at runtime.
-- [Example Config](docs/EXAMPLE_CONFIG.md) – sample `AppConfig` file.
+See [docs/USER_GUIDE.md](docs/USER_GUIDE.md) for configuration, optional features and build instructions.
 - [Release Artifacts Guide](docs/RELEASE_ARTIFACTS.md#release-process) – how to create installers and sign them.
 
 ## Sync CLI

--- a/docs/EXAMPLE_CONFIG.md
+++ b/docs/EXAMPLE_CONFIG.md
@@ -1,6 +1,8 @@
 # Example Config
 
-Create `~/.googlepicz/config` with all fields of the `AppConfig` struct:
+Create `~/.googlepicz/config` with all fields of the `AppConfig` struct. Video
+playback and face recognition are compile-time features and are **not**
+configured here:
 
 ```toml
 log_level = "debug"

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,104 @@
+# User Guide
+
+## Overview
+GooglePicz is an early stage native Google Photos client. The workspace contains several crates for the UI, synchronization and optional features like face recognition.
+
+## Configuration Options
+The application reads `AppConfig` from `~/.googlepicz/config`. Available keys are:
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `log_level` | `String` | `"info"` | Verbosity of application logging. |
+| `oauth_redirect_port` | `u16` | `8080` | Port used during the OAuth flow. |
+| `thumbnails_preload` | `usize` | `20` | Number of thumbnails to preload. |
+| `sync_interval_minutes` | `u64` | `5` | Minutes between automatic sync runs. |
+| `cache_path` | `String` | `"~/.googlepicz"` | Location for cache and logs. |
+| `debug_console` | `bool` | `false` | Enable the Tokio console subscriber. |
+| `trace_spans` | `bool` | `false` | Record tracing spans when built with the `trace-spans` features. |
+
+### Example Config
+Create `~/.googlepicz/config` and adjust the values as needed:
+
+```toml
+log_level = "debug"
+oauth_redirect_port = 9000
+thumbnails_preload = 30
+sync_interval_minutes = 15
+cache_path = "/tmp/googlepicz"
+debug_console = false
+trace_spans = false
+```
+
+### Environment Variables
+The following variables influence GooglePicz and the packager:
+
+- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` – OAuth credentials.
+- `MAC_SIGN_ID` – macOS signing identity (optional).
+- `APPLE_ID` and `APPLE_PASSWORD` – credentials for notarization (optional).
+- `WINDOWS_CERT` and `WINDOWS_CERT_PASSWORD` – Windows code signing certificate (optional).
+- `LINUX_SIGN_KEY` – GPG key ID to sign Debian packages (optional).
+- `MOCK_REFRESH_TOKEN` – used only for tests.
+- `MOCK_COMMANDS` – skip external tools during packaging tests.
+- `USE_FILE_STORE` – write tokens to `~/.googlepicz/tokens.json` when set to `1` and compiled with the `file-store` feature.
+- `MOCK_API_CLIENT` and `MOCK_KEYRING` – together with `MOCK_ACCESS_TOKEN` allow running tests without network access.
+
+## Optional Features
+
+### Video Playback
+Video support relies on GStreamer. Install `glib2.0-dev`, `gstreamer1.0-dev` and `libssl-dev` (or the equivalents for your distribution) before building. If these libraries are unavailable, build the `ui` crate without default features:
+
+```bash
+cargo build -p ui --no-default-features
+```
+
+Without GStreamer the application still runs but cannot play videos.
+
+### Face Recognition
+The `face_recognition` crate can detect faces in a `MediaItem`. Building with the `cache` feature stores the results in the local database, and the `ui` feature displays bounding boxes. This module is experimental and disabled by default.
+
+### Building Without Extras
+Compile the workspace without the video and face recognition crates:
+
+```bash
+cargo build --workspace --no-default-features --exclude face_recognition --exclude e2e
+```
+
+Individual crates can also be built without optional features:
+
+```bash
+cargo build -p ui --no-default-features
+cargo build -p face_recognition --no-default-features
+```
+
+## Profiling
+Install `tokio-console` once:
+
+```bash
+cargo install tokio-console
+```
+
+Run it in a separate terminal and launch GooglePicz with tracing enabled:
+
+```bash
+cargo run --package googlepicz --features sync/trace-spans,ui/trace-spans -- --debug-console --trace-spans
+```
+
+The console shows active tasks while span data is written to `~/.googlepicz/googlepicz.log`.
+
+## Packaging
+To create installers:
+
+1. Install the tools listed in `docs/RELEASE_ARTIFACTS.md#required-tools`.
+2. Export signing variables like `MAC_SIGN_ID` or `WINDOWS_CERT`.
+3. Run:
+
+   ```bash
+   cargo run --package packaging --bin packager
+   ```
+
+Artifacts appear in `target/` (e.g. `GooglePicz-<version>-Setup.exe` or `.deb`).
+
+## Command Line Interface
+The workspace provides `sync_cli` for manual synchronization and cache inspection. Run `--help` for available subcommands. It respects the same configuration and environment variables as the GUI.
+
+


### PR DESCRIPTION
## Summary
- add new User Guide consolidating configuration, features and packaging
- update example config with note about optional build features
- point README to central guide

## Testing
- `cargo test` *(fails: command interrupted due to long compile)*

------
https://chatgpt.com/codex/tasks/task_e_6869b394a3188333b4ab51e42e18fbc7