### PR TITLE
Enable face recognition with cache + UI features

### DIFF
--- a/face_recognition/Cargo.toml
+++ b/face_recognition/Cargo.toml
@@ -19,5 +19,6 @@ tempfile = "3"
 
 [features]
 cache = ["dep:cache"]
+ui = []
 trace-spans = []
 default = []

--- a/face_recognition/src/lib.rs
+++ b/face_recognition/src/lib.rs
@@ -83,6 +83,12 @@ impl FaceRecognizer {
             .map(|r| Face {
                 bbox: [r.x, r.y, r.width, r.height],
                 name: None,
+                rect: (
+                    r.x.max(0) as u32,
+                    r.y.max(0) as u32,
+                    r.width as u32,
+                    r.height as u32,
+                ),
             })
             .collect();
         Ok(faces)

--- a/face_recognition/tests/roundtrip.rs
+++ b/face_recognition/tests/roundtrip.rs
@@ -1,0 +1,49 @@
+use face_recognition::FaceRecognizer;
+use base64::Engine;
+use api_client::{MediaItem, MediaMetadata};
+use cache::CacheManager;
+
+const SAMPLE_IMAGE_B64: &str = include_str!("./face_image.b64");
+
+fn prepare_sample_file() -> std::path::PathBuf {
+    let engine = base64::engine::general_purpose::STANDARD;
+    let data = engine
+        .decode(SAMPLE_IMAGE_B64.replace('\n', "").as_bytes())
+        .expect("decode");
+    let path = std::env::temp_dir().join("face_sample_roundtrip.jpg");
+    std::fs::write(&path, &data).expect("write");
+    path
+}
+
+#[test]
+fn test_detect_and_cache_roundtrip() {
+    let img = prepare_sample_file();
+    let item = MediaItem {
+        id: "r1".into(),
+        description: None,
+        product_url: String::new(),
+        base_url: format!("file://{}", img.display()),
+        mime_type: "image/jpeg".into(),
+        media_metadata: MediaMetadata {
+            creation_time: "2024-01-01T00:00:00Z".into(),
+            width: "200".into(),
+            height: "200".into(),
+            video: None,
+        },
+        filename: "sample.jpg".into(),
+    };
+
+    let cache_file = tempfile::NamedTempFile::new().expect("tmpfile");
+    let cache = CacheManager::new(cache_file.path()).expect("cache");
+    cache.insert_media_item(&item).expect("insert item");
+
+    let rec = FaceRecognizer::new();
+    let faces = rec.detect_faces(&item).expect("detect");
+    assert!(!faces.is_empty());
+
+    rec.assign_to_cache(&cache, &item, &faces)
+        .expect("cache faces");
+
+    let stored = cache.get_faces(&item.id).expect("get").unwrap();
+    assert_eq!(stored.len(), faces.len());
+}

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -16,7 +16,7 @@ auth = { path = "../auth" }
 tracing = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
-face_recognition = { path = "../face_recognition", default-features = false }
+face_recognition = { path = "../face_recognition", default-features = false, features = ["cache", "ui"] }
 futures = "0.3"
 gstreamer_iced = { version = "0.1.8", optional = true }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- add missing `ui` feature for face_recognition
- compile UI with face_recognition cache+ui features
- store rectangle info when detecting faces
- test roundtrip from detection to cache

## Testing
- `cargo test -p face_recognition --features cache,ui` *(fails: could not find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_6869b395b31c8333a76c84c07b2c3a77