### PR TITLE
Add installer tool checks

### DIFF
--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -423,6 +423,7 @@ fn create_appimage_package() -> Result<(), PackagingError> {
 
 #[cfg_attr(feature = "trace-spans", tracing::instrument)]
 pub fn create_installer() -> Result<(), PackagingError> {
+    utils::verify_installer_tools()?;
     if cfg!(target_os = "macos") {
         create_macos_installer()?;
         let root = get_project_root();

--- a/packaging/src/utils.rs
+++ b/packaging/src/utils.rs
@@ -136,3 +136,10 @@ pub fn write_checksums() -> Result<(), PackagingError> {
         PackagingError::Other(format!("Failed to write checksums.txt: {}", e))
     })
 }
+
+/// Verify that all external tools required for creating an installer are
+/// available on the system. This delegates to the crate level `verify_tools`
+/// function which performs the actual checks.
+pub fn verify_installer_tools() -> Result<(), PackagingError> {
+    crate::verify_tools()
+}

--- a/packaging/tests/missing_tools.rs
+++ b/packaging/tests/missing_tools.rs
@@ -1,0 +1,14 @@
+use packaging::utils::verify_installer_tools;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn test_verify_installer_tools_mock_skips_missing() {
+    let orig_path = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", "");
+    std::env::set_var("MOCK_COMMANDS", "1");
+    let result = verify_installer_tools();
+    assert!(result.is_ok(), "expected success when MOCK_COMMANDS is set");
+    std::env::remove_var("MOCK_COMMANDS");
+    std::env::set_var("PATH", orig_path);
+}


### PR DESCRIPTION
## Summary
- check for required tools before creating an installer
- expose helper in `utils` to reuse tool verification
- test skipping tool checks when `MOCK_COMMANDS` is set

## Testing
- `cargo test -p packaging`

------
https://chatgpt.com/codex/tasks/task_e_6869bb4e29d48333bf14eb50ef98c478