### PR TITLE
Add text query benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,32 @@ jobs:
 
       - uses: ./.github/actions/checks
 
+  bench-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run cache benchmarks
+        run: cargo bench -p cache
+
   packaging-tests:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/cache/benches/cache_bench.rs
+++ b/cache/benches/cache_bench.rs
@@ -198,6 +198,114 @@ fn bench_filename_query(c: &mut Criterion) {
     });
 }
 
+fn bench_text_query_get_1k(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..1_000u32 {
+        let mut item = sample_media_item(&i.to_string());
+        if i % 2 == 0 {
+            item.description = Some("foo".into());
+        }
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("get_text_1k", |b| {
+        b.iter(|| {
+            let _ = cache.get_media_items_by_text("foo").unwrap();
+        })
+    });
+}
+
+fn bench_text_query_get_10k(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..10_000u32 {
+        let mut item = sample_media_item(&i.to_string());
+        if i % 2 == 0 {
+            item.description = Some("foo".into());
+        }
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("get_text_10k", |b| {
+        b.iter(|| {
+            let _ = cache.get_media_items_by_text("foo").unwrap();
+        })
+    });
+}
+
+fn bench_text_query_get_100k(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..100_000u32 {
+        let mut item = sample_media_item(&i.to_string());
+        if i % 2 == 0 {
+            item.description = Some("foo".into());
+        }
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("get_text_100k", |b| {
+        b.iter(|| {
+            let _ = cache.get_media_items_by_text("foo").unwrap();
+        })
+    });
+}
+
+fn bench_text_query_general_1k(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..1_000u32 {
+        let mut item = sample_media_item(&i.to_string());
+        if i % 2 == 0 {
+            item.description = Some("foo".into());
+        }
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("query_text_1k", |b| {
+        b.iter(|| {
+            let _ = cache
+                .query_media_items(None, None, None, None, Some("foo"))
+                .unwrap();
+        })
+    });
+}
+
+fn bench_text_query_general_10k(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..10_000u32 {
+        let mut item = sample_media_item(&i.to_string());
+        if i % 2 == 0 {
+            item.description = Some("foo".into());
+        }
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("query_text_10k", |b| {
+        b.iter(|| {
+            let _ = cache
+                .query_media_items(None, None, None, None, Some("foo"))
+                .unwrap();
+        })
+    });
+}
+
+fn bench_text_query_general_100k(c: &mut Criterion) {
+    let tmp = NamedTempFile::new().unwrap();
+    let cache = CacheManager::new(tmp.path()).unwrap();
+    for i in 0..100_000u32 {
+        let mut item = sample_media_item(&i.to_string());
+        if i % 2 == 0 {
+            item.description = Some("foo".into());
+        }
+        cache.insert_media_item(&item).unwrap();
+    }
+    c.bench_function("query_text_100k", |b| {
+        b.iter(|| {
+            let _ = cache
+                .query_media_items(None, None, None, None, Some("foo"))
+                .unwrap();
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_load_all,
@@ -206,6 +314,12 @@ criterion_group!(
     bench_camera_model_query,
     bench_camera_make_query,
     bench_filename_query,
+    bench_text_query_get_1k,
+    bench_text_query_get_10k,
+    bench_text_query_get_100k,
+    bench_text_query_general_1k,
+    bench_text_query_general_10k,
+    bench_text_query_general_100k,
     bench_mime_type_query,
     bench_album_query
 );


### PR DESCRIPTION
## Summary
- benchmark text-based queries in cache crate
- run benchmarks for cache crate in CI

## Testing
- `cargo check -p cache` *(fails: module is not supported in `trait`s or `impl`s)*
- `rustup component add rustfmt` *(fails to download component)*

------
https://chatgpt.com/codex/tasks/task_e_6869bb4e675c83339df77743cd031e85