### PR TITLE
Consolidate UI styles and unify icon usage

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1334,13 +1334,14 @@ impl Application for GooglePiczUI {
             text_input("To", &self.search_end)
                 .style(style::text_input_basic())
                 .on_input(Message::SearchEndChanged),
-            checkbox("Fav", self.search_favorite, Message::SearchFavoriteToggled),
+            checkbox("Fav", self.search_favorite, Message::SearchFavoriteToggled)
+                .style(style::checkbox_primary()),
             pick_list(
                 &SearchMode::ALL[..],
                 Some(self.search_mode),
                 Message::SearchModeChanged,
             ),
-            button("Search")
+            button(Icon::new(MaterialSymbol::Search).color(Palette::ON_PRIMARY))
                 .style(style::button_primary())
                 .on_press(Message::PerformSearch)
         ];
@@ -1389,7 +1390,7 @@ impl Application for GooglePiczUI {
             for (i, msg) in self.errors.iter().enumerate() {
                 let row = row![
                     text(msg.clone()).size(16),
-                    button("Dismiss")
+                    button(Icon::new(MaterialSymbol::Close).color(Palette::ON_PRIMARY))
                         .style(style::button_primary())
                         .on_press(Message::DismissError(i))
                 ]
@@ -1400,7 +1401,7 @@ impl Application for GooglePiczUI {
             let banner = column![
                 row![
                     text("Operation failed").size(16),
-                    button("Dismiss All")
+                    button(Icon::new(MaterialSymbol::Close).color(Palette::ON_PRIMARY))
                         .style(style::button_primary())
                         .on_press(Message::ClearErrors)
                 ]
@@ -1501,20 +1502,22 @@ impl Application for GooglePiczUI {
                         "Debug console",
                         self.settings_debug_console,
                         Message::SettingsDebugConsoleToggled,
-                    ),
+                    )
+                        .style(style::checkbox_primary()),
                     checkbox(
                         "Trace spans",
                         self.settings_trace_spans,
                         Message::SettingsTraceSpansToggled,
-                    ),
+                    )
+                        .style(style::checkbox_primary()),
                     text_input("Cache path", &self.settings_cache_path)
                         .style(style::text_input_basic())
                         .on_input(Message::SettingsCachePathChanged),
                     row![
-                        button("Save")
+                        button(Icon::new(MaterialSymbol::Save).color(Palette::ON_PRIMARY))
                             .style(style::button_primary())
                             .on_press(Message::SaveSettings),
-                        button("Cancel")
+                        button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_PRIMARY))
                             .style(style::button_primary())
                             .on_press(Message::CloseSettings)
                     ]
@@ -1593,7 +1596,7 @@ impl Application for GooglePiczUI {
                     let mut grid = column![].spacing(10);
                     if self.display_limit < self.photos.len() {
                         grid = grid.push(
-                            button("Load more")
+                            button(Icon::new(MaterialSymbol::ExpandMore).color(Palette::ON_PRIMARY))
                                 .style(style::button_primary())
                                 .on_press(Message::LoadMorePhotos),
                         );
@@ -1651,7 +1654,7 @@ impl Application for GooglePiczUI {
                                 face.bbox[3],
                                 face.name.clone().unwrap_or_else(|| "?".into())
                             )),
-                            button("Rename")
+                            button(Icon::new(MaterialSymbol::Edit).color(Palette::ON_PRIMARY))
                                 .style(style::button_primary())
                                 .on_press(Message::StartRenameFace(i))
                         ]

--- a/ui/src/style.rs
+++ b/ui/src/style.rs
@@ -5,7 +5,14 @@
 //! application keeps a consistent Material look.
 
 use iced::{Color, Border};
-use iced::widget::{self, button, container, text_input};
+use iced::widget::{
+    self,
+    button,
+    checkbox,
+    container,
+    slider::{self, Handle, HandleShape, Rail},
+    text_input,
+};
 use iced::theme;
 
 /// Material color palette
@@ -58,6 +65,43 @@ pub fn card() -> theme::Container {
             radius: 4.0.into(),
         },
         shadow: Default::default(),
+    }))
+}
+
+/// Style for checkboxes using the primary color.
+pub fn checkbox_primary() -> theme::Checkbox {
+    theme::Checkbox::Custom(Box::new(|_theme: &iced::Theme, is_checked: bool| {
+        checkbox::Appearance {
+            background: if is_checked {
+                Palette::PRIMARY.into()
+            } else {
+                Palette::SURFACE.into()
+            },
+            icon_color: Palette::ON_PRIMARY,
+            border: Border {
+                color: Palette::PRIMARY,
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            text_color: None,
+        }
+    }))
+}
+
+/// Style for sliders matching the primary color palette.
+pub fn slider_primary() -> theme::Slider {
+    theme::Slider::Custom(Box::new(|_theme: &iced::Theme| slider::Appearance {
+        rail: slider::Rail {
+            colors: (Palette::PRIMARY, Palette::SURFACE),
+            width: 4.0,
+            border_radius: 2.0.into(),
+        },
+        handle: slider::Handle {
+            shape: slider::HandleShape::Circle { radius: 6.0 },
+            color: Palette::PRIMARY,
+            border_width: 1.0,
+            border_color: Palette::ON_PRIMARY,
+        },
     }))
 }
 


### PR DESCRIPTION
## Summary
- add checkbox and slider styles to `ui` style utilities
- restyle checkboxes in the UI
- swap text labels for icons in action buttons

## Testing
- `cargo check -p ui --no-default-features --features no-gstreamer` *(fails: could not find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686a531e12a08333a614bef691d1df64