### PR TITLE
Add CLI search test

### DIFF
--- a/app/tests/cli.rs
+++ b/app/tests/cli.rs
@@ -56,3 +56,17 @@ fn sync_cli_cache_stats_no_cache() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn sync_cli_search_no_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_home = TempDir::new()?;
+    let mut cmd = Command::cargo_bin("sync_cli")?;
+    cmd.args(["search", "test"]);
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("HOME", tmp_home.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No cache found"));
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- ensure CLI search works with empty cache

## Testing
- `cargo test -p googlepicz --no-default-features --features ui/no-gstreamer --no-run` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a531a1204833393a839abaf455f69