### PR TITLE
Enable face overlay from cached data

### DIFF
--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -1152,6 +1152,19 @@ impl CacheManager {
         Ok(())
     }
 
+    #[cfg(feature = "face-recognition")]
+    #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self, faces_json)))]
+    pub async fn insert_faces_async(
+        &self,
+        media_item_id: String,
+        faces_json: String,
+    ) -> Result<(), CacheError> {
+        let this = self.clone();
+        tokio::task::spawn_blocking(move || this.insert_faces(&media_item_id, &faces_json))
+            .await
+            .map_err(|e| CacheError::Other(e.to_string()))?
+    }
+
     #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self)))]
     pub fn get_faces(&self, media_item_id: &str) -> Result<Option<Vec<FaceData>>, CacheError> {
         let conn = self.lock_conn()?;

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -57,10 +57,12 @@ Without GStreamer the application still runs but cannot play videos.
 
 ### Face Recognition
 The `face_recognition` crate can detect faces in a `MediaItem`. Building with
-the `cache` feature stores the results in the local database, and the `ui`
-feature displays bounding boxes. When these features are enabled the sync
-process automatically runs face detection and persists the bounding boxes. This
-module is experimental and disabled by default.
+the `cache` feature stores the results permanently using `insert_faces` from
+`cache::CacheManager`. When the `ui` feature is also enabled the
+`ui::FaceRecognizer` widget overlays the saved bounding boxes whenever a photo
+is opened. The sync process automatically runs face detection and persists the
+boxes, making them available across sessions. This module is experimental and
+disabled by default.
 
 ### Building Without Extras
 Compile the workspace without the video and face recognition crates:

--- a/ui/src/face_recognizer.rs
+++ b/ui/src/face_recognizer.rs
@@ -1,0 +1,37 @@
+use iced::widget::canvas::{self, Canvas, Frame, Geometry, Path, Program, Stroke};
+use iced::{Color, Rectangle, Size, Point};
+
+#[derive(Debug, Clone)]
+pub struct FaceRecognizer {
+    faces: Vec<face_recognition::Face>,
+    width: u32,
+    height: u32,
+}
+
+impl FaceRecognizer {
+    pub fn new(faces: Vec<face_recognition::Face>, width: u32, height: u32) -> Self {
+        Self { faces, width, height }
+    }
+
+    pub fn view<'a, Message>(self) -> Canvas<'a, Message, Self> {
+        Canvas::new(self)
+    }
+}
+
+impl<Message> Program<Message> for FaceRecognizer {
+    type State = ();
+
+    fn draw(&self, _state: &Self::State, bounds: Rectangle, _cursor: iced::mouse::Cursor) -> Vec<Geometry> {
+        let mut frame = Frame::new(bounds.size());
+        let sx = bounds.width / self.width.max(1) as f32;
+        let sy = bounds.height / self.height.max(1) as f32;
+        for face in &self.faces {
+            let path = Path::rectangle(
+                Point::new(face.bbox[0] as f32 * sx, face.bbox[1] as f32 * sy),
+                Size::new(face.bbox[2] as f32 * sx, face.bbox[3] as f32 * sy),
+            );
+            frame.stroke(&path, Stroke { color: Color::from_rgb(1.0, 0.0, 0.0), width: 2.0, ..Stroke::default() });
+        }
+        vec![frame.into_geometry()]
+    }
+}

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -6,8 +6,10 @@ mod video_downloader;
 mod app_config;
 mod style;
 mod icon;
+mod face_recognizer;
 
 pub use icon::{Icon, MaterialSymbol};
+pub use face_recognizer::FaceRecognizer;
 
 pub use image_loader::{ImageLoader, ImageLoaderError};
 pub use video_downloader::{VideoDownloader, VideoDownloadError};
@@ -1612,9 +1614,15 @@ impl Application for GooglePiczUI {
             }
             ViewState::SelectedPhoto { photo, faces } => {
                 let img: Element<Message> = if let Some(handle) = self.full_images.get(&photo.id) {
-                    image(handle.clone())
+                    let base = image(handle.clone())
+                        .width(Length::Fill)
+                        .height(Length::Fill);
+                    let w = photo.media_metadata.width.parse::<u32>().unwrap_or(0);
+                    let h = photo.media_metadata.height.parse::<u32>().unwrap_or(0);
+                    container(base)
                         .width(Length::Fill)
                         .height(Length::Fill)
+                        .overlay(FaceRecognizer::new(faces.clone(), w, h).view())
                         .into()
                 } else {
                     container(text("Loading..."))


### PR DESCRIPTION
## Summary
- support async face insertion in `cache`
- show detected faces using new `ui::FaceRecognizer`
- document persistent face data in the user guide

## Testing
- `cargo check -p ui --no-default-features` *(fails: couldn't find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686a67125828833394c1904cc22f3858