### PR TITLE
Unify packager artifact naming

### DIFF
--- a/packaging/tests/ci_checks_bin.rs
+++ b/packaging/tests/ci_checks_bin.rs
@@ -1,6 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
-use packaging::utils::{get_project_root, workspace_version};
+use packaging::utils::{artifact_path, workspace_version};
 use serial_test::serial;
 use std::fs;
 
@@ -8,14 +8,7 @@ use std::fs;
 #[serial]
 fn test_ci_checks_binary() -> Result<(), Box<dyn std::error::Error>> {
     let version = workspace_version()?;
-    let root = get_project_root();
-
-    #[cfg(target_os = "linux")]
-    let path = root.join(format!("GooglePicz-{}.deb", version));
-    #[cfg(target_os = "macos")]
-    let path = root.join(format!("target/release/GooglePicz-{}.dmg", version));
-    #[cfg(target_os = "windows")]
-    let path = root.join(format!("target/windows/GooglePicz-{}-Setup.exe", version));
+    let path = artifact_path(&version);
 
     fs::create_dir_all(path.parent().unwrap())?;
     fs::write(&path, b"test")?;

--- a/packaging/tests/cleanup.rs
+++ b/packaging/tests/cleanup.rs
@@ -9,11 +9,11 @@ fn test_clean_artifacts() -> Result<(), Box<dyn std::error::Error>> {
     let root = get_project_root();
 
     #[cfg(target_os = "linux")]
-    let path = root.join("GooglePicz-temp.deb");
+    let path = root.join("target/GooglePicz-temp.deb");
     #[cfg(target_os = "macos")]
-    let path = root.join("target/release/GooglePicz-temp.dmg");
+    let path = root.join("target/GooglePicz-temp.dmg");
     #[cfg(target_os = "windows")]
-    let path = root.join("target/windows/GooglePicz-temp-Setup.exe");
+    let path = root.join("target/GooglePicz-temp.exe");
 
     fs::create_dir_all(path.parent().unwrap())?;
     fs::write(&path, b"test")?;

--- a/packaging/tests/installer_artifacts.rs
+++ b/packaging/tests/installer_artifacts.rs
@@ -1,5 +1,5 @@
 use packaging::create_installer;
-use packaging::utils::{get_project_root, workspace_version};
+use packaging::utils::{artifact_path, get_project_root, workspace_version};
 use serial_test::serial;
 use std::fs;
 
@@ -16,7 +16,7 @@ fn test_linux_installer_artifact_exists() -> Result<(), Box<dyn std::error::Erro
 
     create_installer()?;
     let version = workspace_version()?;
-    let deb = root.join(format!("GooglePicz-{}.deb", version));
+    let deb = artifact_path(&version);
     assert!(deb.exists());
     fs::remove_file(deb)?;
 
@@ -39,7 +39,7 @@ fn test_macos_installer_artifact_exists() -> Result<(), Box<dyn std::error::Erro
 
     create_installer()?;
     let version = workspace_version()?;
-    let dmg = release.join(format!("GooglePicz-{}.dmg", version));
+    let dmg = artifact_path(&version);
     assert!(dmg.exists());
     fs::remove_file(dmg)?;
 
@@ -56,13 +56,13 @@ fn test_windows_installer_artifact_exists() -> Result<(), Box<dyn std::error::Er
     let win_dir = root.join("target/windows");
     fs::create_dir_all(&win_dir)?;
     let version = workspace_version()?;
-    fs::write(win_dir.join(format!("GooglePicz-{}-Setup.exe", version)), b"test")?;
+    fs::write(win_dir.join(format!("GooglePicz-{}-Setup.exe", version)), b"test")?; // produced path
     let rel_dir = root.join("target/release");
     fs::create_dir_all(&rel_dir)?;
     fs::write(rel_dir.join("googlepicz.exe"), b"test")?;
 
     create_installer()?;
-    let exe = win_dir.join(format!("GooglePicz-{}-Setup.exe", version));
+    let exe = artifact_path(&version);
     assert!(exe.exists());
     fs::remove_file(exe)?;
     fs::remove_file(rel_dir.join("googlepicz.exe"))?;

--- a/packaging/tests/package_all.rs
+++ b/packaging/tests/package_all.rs
@@ -1,5 +1,5 @@
 use packaging::package_all;
-use packaging::utils::{get_project_root, workspace_version};
+use packaging::utils::{artifact_path, get_project_root, workspace_version};
 use serial_test::serial;
 use std::fs;
 
@@ -48,26 +48,21 @@ fn test_package_all_mock() {
 
     if cfg!(target_os = "linux") {
         let version = workspace_version().unwrap();
-        let format = std::env::var("LINUX_PACKAGE_FORMAT").unwrap_or_else(|_| "deb".into());
-        let file = match format.as_str() {
-            "rpm" => root.join(format!("GooglePicz-{}.rpm", version)),
-            "appimage" => root.join(format!("GooglePicz-{}.AppImage", version)),
-            _ => root.join(format!("GooglePicz-{}.deb", version)),
-        };
+        let file = artifact_path(&version);
         assert!(file.exists(), "Expected {:?} to exist", file);
         fs::remove_file(file).unwrap();
     }
 
     if cfg!(target_os = "macos") {
         let version = workspace_version().unwrap();
-        let dmg = root.join(format!("target/release/GooglePicz-{}.dmg", version));
+        let dmg = artifact_path(&version);
         assert!(dmg.exists(), "Expected {:?} to exist", dmg);
         fs::remove_file(dmg).unwrap();
     }
 
     if cfg!(target_os = "windows") {
         let version = workspace_version().unwrap();
-        let exe = root.join(format!("target/windows/GooglePicz-{}-Setup.exe", version));
+        let exe = artifact_path(&version);
         assert!(exe.exists(), "Expected {:?} to exist", exe);
         fs::remove_file(exe).unwrap();
     }
@@ -77,6 +72,48 @@ fn test_package_all_mock() {
 
     if !use_real {
         std::env::remove_var("MOCK_COMMANDS");
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[serial]
+fn test_package_all_all_formats() {
+    let formats = ["deb", "rpm", "appimage"];
+    for fmt in &formats {
+        std::env::set_var("MOCK_COMMANDS", "1");
+        std::env::set_var("LINUX_PACKAGE_FORMAT", fmt);
+
+        let root = get_project_root();
+        // create dummy artifact for each format
+        match *fmt {
+            "rpm" => {
+                let dir = root.join("target/rpmbuild/RPMS");
+                fs::create_dir_all(&dir).unwrap();
+                fs::write(dir.join("dummy.rpm"), b"test").unwrap();
+            }
+            "appimage" => {
+                let dir = root.join("target/appimage");
+                fs::create_dir_all(&dir).unwrap();
+                fs::write(dir.join("dummy.AppImage"), b"test").unwrap();
+            }
+            _ => {
+                let dir = root.join("target/debian");
+                fs::create_dir_all(&dir).unwrap();
+                fs::write(dir.join("dummy.deb"), b"test").unwrap();
+            }
+        }
+
+        package_all().unwrap();
+
+        let version = workspace_version().unwrap();
+        let artifact = artifact_path(&version);
+        assert!(artifact.exists());
+        fs::remove_file(&artifact).unwrap();
+        let _ = fs::remove_file(root.join("checksums.txt"));
+
+        std::env::remove_var("MOCK_COMMANDS");
+        std::env::remove_var("LINUX_PACKAGE_FORMAT");
     }
 }
 

--- a/packaging/tests/packager_cli.rs
+++ b/packaging/tests/packager_cli.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use packaging::utils::{get_project_root, workspace_version};
+use packaging::utils::{artifact_path, get_project_root, workspace_version};
 use serial_test::serial;
 use std::fs;
 
@@ -26,7 +26,7 @@ fn test_packager_cli_format() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
     {
         let version = workspace_version()?;
-        let rpm = root.join(format!("GooglePicz-{}.rpm", version));
+        let rpm = artifact_path(&version);
         assert!(rpm.exists());
         fs::remove_file(rpm)?;
     }

--- a/packaging/tests/utils.rs
+++ b/packaging/tests/utils.rs
@@ -4,6 +4,7 @@ use packaging::utils::{
     verify_metadata_package_name,
     verify_artifact_names,
     write_checksums,
+    artifact_path,
 };
 use serial_test::serial;
 use toml::Value;
@@ -44,15 +45,7 @@ fn test_get_project_root() -> Result<(), Box<dyn std::error::Error>> {
 #[serial]
 fn test_verify_artifact_names() -> Result<(), Box<dyn std::error::Error>> {
     let version = workspace_version()?;
-    let root = get_project_root();
-
-    // create dummy artifact based on target OS
-    #[cfg(target_os = "linux")]
-    let path = root.join(format!("GooglePicz-{}.deb", version));
-    #[cfg(target_os = "macos")]
-    let path = root.join(format!("target/release/GooglePicz-{}.dmg", version));
-    #[cfg(target_os = "windows")]
-    let path = root.join(format!("target/windows/GooglePicz-{}-Setup.exe", version));
+    let path = artifact_path(&version);
 
     std::fs::create_dir_all(path.parent().unwrap())?;
     std::fs::write(&path, b"test")?;
@@ -67,14 +60,8 @@ fn test_verify_artifact_names() -> Result<(), Box<dyn std::error::Error>> {
 #[serial]
 fn test_write_checksums() -> Result<(), Box<dyn std::error::Error>> {
     let version = workspace_version()?;
+    let path = artifact_path(&version);
     let root = get_project_root();
-
-    #[cfg(target_os = "linux")]
-    let path = root.join(format!("GooglePicz-{}.deb", version));
-    #[cfg(target_os = "macos")]
-    let path = root.join(format!("target/release/GooglePicz-{}.dmg", version));
-    #[cfg(target_os = "windows")]
-    let path = root.join(format!("target/windows/GooglePicz-{}-Setup.exe", version));
 
     std::fs::create_dir_all(path.parent().unwrap())?;
     std::fs::write(&path, b"test")?;


### PR DESCRIPTION
## Summary
- simplify path handling in packaging utils
- store release artifacts in `target/GooglePicz-<version>-<platform>.<ext>`
- adjust packager code to use the unified paths
- extend packaging tests for all linux package formats

## Testing
- `cargo test -p packaging -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_686a67132bf88333b32bce44386dd157