### PR TITLE
Update release workflow and docs

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+    tags: ['*']
+  release:
+    types: [published]
   pull_request:
 
 jobs:
@@ -54,12 +57,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: googlepicz-linux
-          path: GooglePicz-*.*
+          path: target/GooglePicz-*.*
       - name: Release Linux artifact
         if: runner.os == 'Linux' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: GooglePicz-*.*
+          files: target/GooglePicz-*.*
       - name: Upload macOS artifact
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4

--- a/docs/RELEASE_ARTIFACTS.md
+++ b/docs/RELEASE_ARTIFACTS.md
@@ -115,10 +115,12 @@ reproducible artifact names across Linux, macOS and Windows.
 
 ### GitHub Actions
 
-The workflow in `.github/workflows/rust.yml` runs the packager on
-Linux, macOS and Windows. Each run uploads the generated `.deb`, `.dmg`
-and Windows installer via `upload-artifact`. You can download these
-artifacts from the workflow run page without building them locally.
+The workflow in `.github/workflows/packager.yml` runs the packager on
+Linux, macOS and Windows. It executes
+`cargo run --package packaging --bin packager` and uploads the resulting
+artifacts from the `target` directory via `upload-artifact`. You can
+download these packages from the workflow run page without building them
+locally.
 
 ## Release Process {#release-process}
 
@@ -145,7 +147,7 @@ The generated installers can be attached to a GitHub release either via the web
 interface or using the `gh` CLI:
 
 ```bash
-gh release upload <tag> target/release/GooglePicz-*.dmg GooglePicz-*.{deb,rpm,AppImage} target/windows/GooglePicz-*-Setup.exe
+gh release upload <tag> target/release/GooglePicz-*.dmg target/GooglePicz-*.{deb,rpm,AppImage} target/windows/GooglePicz-*-Setup.exe
 ```
 
 Replace `<tag>` with the version tag you are publishing. Drag‑and‑drop also


### PR DESCRIPTION
## Summary
- build release packages in `packager.yml` on pushes, tags and releases
- store and upload Linux artifacts from the `target` directory
- document that `packager.yml` builds the release artifacts
- fix release upload example

## Testing
- `cargo test -p packaging`
- `cargo fmt --all -- --check` *(failed: component missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a7729cb2883338c9d3588bf0d21b8