### PR TITLE
Improve sync status reporting

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -258,6 +258,10 @@ After five consecutive failures the task emits `SyncTaskError::Aborted` and
 terminates. The join handle now resolves to `Result<(), SyncTaskError>` so callers
 can check why the loop ended.
 
+A dedicated status channel (`mpsc::UnboundedSender<SyncTaskError>`) can be passed
+to `start_periodic_sync` so the UI receives `RestartAttempt`, `Aborted` and other
+`SyncTaskError` variants reliably.
+
 `start_token_refresh_task` behaves the same but only refreshes the OAuth token.
 
 | Variant | Meaning |

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -365,7 +365,7 @@ impl Syncer {
         interval: Duration,
         progress_tx: mpsc::UnboundedSender<SyncProgress>,
         error_tx: mpsc::UnboundedSender<SyncTaskError>,
-        status_tx: Option<mpsc::UnboundedSender<u32>>,
+        status_tx: Option<mpsc::UnboundedSender<SyncTaskError>>,
         ui_progress_tx: Option<mpsc::UnboundedSender<SyncProgress>>,
         ui_error_tx: Option<mpsc::UnboundedSender<SyncTaskError>>,
     ) -> (JoinHandle<Result<(), SyncTaskError>>, oneshot::Sender<()>) {
@@ -441,7 +441,7 @@ impl Syncer {
                             }
                             failures += 1;
                             if let Some(tx) = &status_tx {
-                                let _ = tx.send(failures);
+                                let _ = tx.send(SyncTaskError::RestartAttempt(failures));
                             }
                             let wait = backoff.min(300);
                             if let Err(send_err) = error_tx.send(SyncTaskError::RestartAttempt(failures)) {
@@ -465,9 +465,13 @@ impl Syncer {
                             if failures >= MAX_FAILURES {
                                 let abort_msg = format!("periodic sync aborted after {} failures", failures);
                                 tracing::error!("{}", abort_msg);
-                                let _ = error_tx.send(SyncTaskError::Aborted(abort_msg.clone()));
-                                Self::forward(&ui_error_tx, SyncTaskError::Aborted(abort_msg.clone()));
-                                return Err(SyncTaskError::Aborted(abort_msg));
+                                let abort_err = SyncTaskError::Aborted(abort_msg.clone());
+                                let _ = error_tx.send(abort_err.clone());
+                                Self::forward(&ui_error_tx, abort_err.clone());
+                                if let Some(tx) = &status_tx {
+                                    let _ = tx.send(abort_err.clone());
+                                }
+                                return Err(abort_err);
                             }
                             sleep(Duration::from_secs(wait)).await;
                         } else {
@@ -475,7 +479,10 @@ impl Syncer {
                             backoff = 1;
                             failures = 0;
                             if let Some(tx) = &status_tx {
-                                let _ = tx.send(0);
+                                let _ = tx.send(SyncTaskError::Status {
+                                    last_synced: last_success,
+                                    message: "Sync completed".into(),
+                                });
                             }
                             let status = SyncTaskError::Status {
                                 last_synced: last_success,
@@ -506,12 +513,16 @@ impl Syncer {
 
         let forward_err = error_tx.clone();
         let forward_ui_err = ui_error_tx.clone();
+        let forward_status = status_tx.clone();
         let handle = spawn_local(async move {
             match sync_task.await {
                 Ok(res) => {
                     if let Err(ref e) = res {
                         let _ = forward_err.send(e.clone());
                         Syncer::forward(&forward_ui_err, e.clone());
+                        if let Some(tx) = &forward_status {
+                            let _ = tx.send(e.clone());
+                        }
                     }
                     res
                 }
@@ -520,6 +531,9 @@ impl Syncer {
                     let err = SyncTaskError::Other { code: SyncErrorCode::Other, message: msg };
                     let _ = forward_err.send(err.clone());
                     Syncer::forward(&forward_ui_err, err.clone());
+                    if let Some(tx) = &forward_status {
+                        let _ = tx.send(err.clone());
+                    }
                     Err(err)
                 }
             }

--- a/sync/tests/abort_restart.rs
+++ b/sync/tests/abort_restart.rs
@@ -29,6 +29,7 @@ async fn test_periodic_sync_abort_and_restart() {
                 None,
                 None,
                 None,
+                None,
             );
             advance(Duration::from_secs(40)).await; // enough for 5 failures
             let result = handle.await.unwrap();
@@ -51,6 +52,7 @@ async fn test_periodic_sync_abort_and_restart() {
                 Duration::from_secs(1),
                 p_tx2,
                 e_tx2,
+                None,
                 None,
                 None,
                 None,

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -21,7 +21,7 @@ async fn test_periodic_sync_reports_error() {
             std::env::remove_var("MOCK_API_CLIENT");
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
-            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None);
+            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None, None);
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));
             let retry = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
@@ -66,7 +66,7 @@ async fn test_periodic_sync_progress_send_failure_forwarded() {
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
             let (handle, shutdown) =
-                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None);
+                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None, None);
             // consume the Started event then drop receiver to cause send failure later
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));

--- a/sync/tests/repeated_failures.rs
+++ b/sync/tests/repeated_failures.rs
@@ -21,7 +21,7 @@ async fn test_periodic_sync_repeated_failures_reported() {
             std::env::remove_var("MOCK_API_CLIENT");
             let (prog_tx, _prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
-            let (status_tx, mut status_rx) = mpsc::unbounded_channel::<u32>();
+            let (status_tx, mut status_rx) = mpsc::unbounded_channel::<SyncTaskError>();
             let (handle, shutdown) = syncer.start_periodic_sync(
                 Duration::from_millis(10),
                 prog_tx,
@@ -32,7 +32,8 @@ async fn test_periodic_sync_repeated_failures_reported() {
             );
             let first = timeout(Duration::from_secs(5), status_rx.recv()).await.unwrap().unwrap();
             let second = timeout(Duration::from_secs(5), status_rx.recv()).await.unwrap().unwrap();
-            assert!(first == 1 && second >= 2);
+            assert!(matches!(first, SyncTaskError::RestartAttempt(1)));
+            assert!(matches!(second, SyncTaskError::RestartAttempt(n) if n >= 2));
             // ensure restart attempts are reported
             let err1 = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap().unwrap();
             let err2 = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap().unwrap();

--- a/sync/tests/token_refresh_task.rs
+++ b/sync/tests/token_refresh_task.rs
@@ -51,7 +51,7 @@ fn test_token_refresh_error_forwarded_to_ui() {
     let dir = tempdir().unwrap();
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SyncError(err));
     assert!(ui.error_count() > 0);
     std::env::remove_var("MOCK_KEYRING");

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -100,12 +100,13 @@ fn error_container_style() -> iced::theme::Container {
 pub fn run(
     progress: Option<mpsc::UnboundedReceiver<SyncProgress>>,
     errors: Option<mpsc::UnboundedReceiver<SyncTaskError>>,
+    status: Option<mpsc::UnboundedReceiver<SyncTaskError>>,
     preload: usize,
     preload_threads: usize,
     cache_dir: PathBuf,
 ) -> iced::Result {
     use std::borrow::Cow;
-    let mut settings = Settings::with_flags((progress, errors, preload, preload_threads, cache_dir));
+    let mut settings = Settings::with_flags((progress, errors, status, preload, preload_threads, cache_dir));
     settings.fonts.push(Cow::Borrowed(google_material_symbols::FONT_BYTES));
     GooglePiczUI::run(settings)
 }
@@ -264,6 +265,7 @@ pub struct GooglePiczUI {
     full_images: std::collections::HashMap<String, Handle>,
     progress_receiver: Option<Arc<Mutex<mpsc::UnboundedReceiver<SyncProgress>>>>,
     error_receiver: Option<Arc<Mutex<mpsc::UnboundedReceiver<SyncTaskError>>>>,
+    status_receiver: Option<Arc<Mutex<mpsc::UnboundedReceiver<SyncTaskError>>>>,
     synced: u64,
     syncing: bool,
     last_synced: Option<DateTime<Utc>>,
@@ -426,6 +428,7 @@ impl Application for GooglePiczUI {
     type Flags = (
         Option<mpsc::UnboundedReceiver<SyncProgress>>,
         Option<mpsc::UnboundedReceiver<SyncTaskError>>,
+        Option<mpsc::UnboundedReceiver<SyncTaskError>>,
         usize,
         usize,
         PathBuf,
@@ -433,7 +436,7 @@ impl Application for GooglePiczUI {
 
     #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(flags)))]
     fn new(flags: Self::Flags) -> (Self, Command<Message>) {
-        let (progress_flag, error_flag, preload_count, preload_threads, cache_dir) = flags;
+        let (progress_flag, error_flag, status_flag, preload_count, preload_threads, cache_dir) = flags;
         let mut init_errors = Vec::new();
         let error_log_path = cache_dir.join("ui_errors.log");
         let cache_path = cache_dir.join("cache.sqlite");
@@ -489,6 +492,7 @@ impl Application for GooglePiczUI {
 
         let progress_receiver = progress_flag.map(|rx| Arc::new(Mutex::new(rx)));
         let error_receiver = error_flag.map(|rx| Arc::new(Mutex::new(rx)));
+        let status_receiver = status_flag.map(|rx| Arc::new(Mutex::new(rx)));
 
         let status = match last_synced {
             Some(ts) => format!("Last synced {}", ts.to_rfc3339()),
@@ -506,6 +510,7 @@ impl Application for GooglePiczUI {
             full_images: std::collections::HashMap::new(),
             progress_receiver,
             error_receiver,
+            status_receiver,
             synced: 0,
             syncing: false,
             last_synced,
@@ -1277,6 +1282,22 @@ impl Application for GooglePiczUI {
         if let Some(error_rx) = &self.error_receiver {
             let error_rx = error_rx.clone();
             subs.push(subscription::unfold("errors", error_rx, |rx| async move {
+                let mut lock = rx.lock().await;
+                let msg = match lock.recv().await {
+                    Some(SyncTaskError::Status { last_synced, message }) => {
+                        Message::SyncStatusUpdated(last_synced, message)
+                    }
+                    Some(e) => Message::SyncError(e),
+                    None => Message::SyncProgress(SyncProgress::Finished(0)),
+                };
+                drop(lock);
+                (msg, rx)
+            }));
+        }
+
+        if let Some(status_rx) = &self.status_receiver {
+            let status_rx = status_rx.clone();
+            subs.push(subscription::unfold("status", status_rx, |rx| async move {
                 let mut lock = rx.lock().await;
                 let msg = match lock.recv().await {
                     Some(SyncTaskError::Status { last_synced, message }) => {

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -33,7 +33,7 @@ fn test_initial_state() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     assert_eq!(ui.photo_count(), 0);
     assert_eq!(ui.album_count(), 0);
     assert_eq!(ui.state_debug(), "Grid");
@@ -46,7 +46,7 @@ fn test_select_and_close_photo() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     let item = sample_item();
 
     let _ = ui.update(Message::SelectPhoto(item.clone()));
@@ -63,7 +63,7 @@ fn test_dismiss_error() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SyncError(SyncTaskError::Other {
         code: SyncErrorCode::Other,
         message: "err".into(),
@@ -80,7 +80,7 @@ fn test_sync_error_added() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SyncError(SyncTaskError::Other {
         code: SyncErrorCode::Other,
         message: "boom".into(),
@@ -95,7 +95,7 @@ fn test_rename_dialog_state() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::ShowRenameAlbumDialog("a1".into(), "Old".into()));
     assert_eq!(ui.renaming_album(), Some("a1".into()));
     assert_eq!(ui.rename_album_title(), "Old");
@@ -110,7 +110,7 @@ fn test_delete_dialog_state() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::ShowDeleteAlbumDialog("a1".into()));
     assert_eq!(ui.deleting_album(), Some("a1".into()));
     let _ = ui.update(Message::CancelDeleteAlbum);
@@ -124,7 +124,7 @@ fn test_search_input() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     let _ = ui.update(Message::SearchInputChanged("query".into()));
     assert_eq!(ui.search_query(), "query");
 }
@@ -136,7 +136,7 @@ fn test_search_mode() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     assert_eq!(ui.search_mode(), SearchMode::Filename);
     let _ = ui.update(Message::SearchModeChanged(SearchMode::Favoriten));
     assert_eq!(ui.search_mode(), SearchMode::Favoriten);
@@ -157,7 +157,7 @@ fn test_settings_dialog() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     assert!(!ui.settings_open());
     let _ = ui.update(Message::ShowSettings);
     assert!(ui.settings_open());
@@ -184,7 +184,7 @@ fn test_save_settings() {
     };
     cfg.save_to(Some(gp_dir.join("config"))).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, gp_dir.clone()));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, gp_dir.clone()));
     let _ = ui.update(Message::ShowSettings);
     ui.update(Message::SettingsLogLevelChanged("debug".into()));
     let new_cache = gp_dir.join("new_cache");
@@ -207,7 +207,7 @@ fn test_faces_loaded_and_rename() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, 4, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, 4, dir.path().join(".googlepicz")));
     let item = sample_item();
 
     let _ = ui.update(Message::SelectPhoto(item.clone()));
@@ -229,7 +229,7 @@ fn test_load_more_photos() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, dir.path().join(".googlepicz")));
     ui.update(Message::PhotosLoaded(Ok(vec![sample_item(); 50])));
     assert!(ui.photo_count() == 50);
     let before = ui.photo_count();
@@ -244,7 +244,7 @@ fn test_cache_path_chosen() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, dir.path().join(".googlepicz")));
     let path = dir.path().join("other");
     let _ = ui.update(Message::CachePathChosen(Some(path.to_path_buf().to_str().unwrap().into())));
     assert_eq!(ui.settings_cache_path(), path.to_string_lossy());
@@ -257,7 +257,7 @@ fn test_escape_closes_photo() {
     std::env::set_var("HOME", dir.path());
     std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
 
-    let (mut ui, _) = GooglePiczUI::new((None, None, 0, dir.path().join(".googlepicz")));
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, dir.path().join(".googlepicz")));
     let item = sample_item();
     ui.update(Message::SelectPhoto(item));
     assert!(ui.state_debug().starts_with("SelectedPhoto"));


### PR DESCRIPTION
## Summary
- enhance `start_periodic_sync` with dedicated `SyncTaskError` status channel
- forward restart attempts and abort information to UI
- hook up new channel in `app` and UI
- document updated behaviour

## Testing
- `cargo test` *(fails: could not compile `clang-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_686a772914ec83339535d66c28ec012a