### PR TITLE
Add cascade model checks and surface errors

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -735,9 +735,17 @@ impl Application for GooglePiczUI {
                         match result {
                             Ok(v) => *faces = v,
                             Err(e) => {
-                                let msg = format!("Failed to load faces: {}", e);
-                                self.errors.push(msg.clone());
-                                self.log_error(&msg);
+                                #[cfg(feature = "face_recognition")]
+                                {
+                                    self.errors.push(e.clone());
+                                    self.log_error(&e);
+                                }
+                                #[cfg(not(feature = "face_recognition"))]
+                                {
+                                    let msg = format!("Failed to load faces: {}", e);
+                                    self.errors.push(msg.clone());
+                                    self.log_error(&msg);
+                                }
                                 return GooglePiczUI::error_timeout();
                             }
                         }


### PR DESCRIPTION
## Summary
- check Haarcascade path at runtime and make it configurable with `OPENCV_HAARCASCADE_PATH`
- forward face detection errors from the syncer to the UI
- display the raw detection error in the UI when face detection is enabled

## Testing
- `cargo test -p face_recognition` *(fails: could not find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686a772818ac8333ae298731fdaf1fb5