### PR TITLE
Enable persistent face naming

### DIFF
--- a/face_recognition/tests/roundtrip.rs
+++ b/face_recognition/tests/roundtrip.rs
@@ -39,7 +39,7 @@ fn test_detect_and_cache_roundtrip() {
 
     let rec = FaceRecognizer::new();
     let faces = rec
-        .detect_and_cache_faces(&cache, &item)
+        .detect_and_cache_faces(&cache, &item, true)
         .expect("detect");
     assert!(!faces.is_empty());
 

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -281,7 +281,7 @@ impl Syncer {
                         let rec = face_recognition::FaceRecognizer::new();
                         #[cfg(feature = "face_recognition/cache")]
                         {
-                            if let Err(e) = rec.detect_and_cache_faces(&cache, &item_clone) {
+                            if let Err(e) = rec.detect_and_cache_faces(&cache, &item_clone, true) {
                                 if let Some(tx) = &ui_err {
                                     let _ = tx.send(SyncTaskError::Other {
                                         code: SyncErrorCode::Other,

--- a/tests/e2e/tests/face_tagging_e2e.rs
+++ b/tests/e2e/tests/face_tagging_e2e.rs
@@ -38,7 +38,7 @@ async fn main() {
     cache.insert_media_item(&item).expect("insert item");
     let recognizer = FaceRecognizer::new();
     let faces = recognizer
-        .detect_and_cache_faces(&cache, &item)
+        .detect_and_cache_faces(&cache, &item, true)
         .expect("detect faces");
 
     let stored = cache.get_faces(&item.id).expect("faces").unwrap();

--- a/ui/src/face_recognizer.rs
+++ b/ui/src/face_recognizer.rs
@@ -1,4 +1,4 @@
-use iced::widget::canvas::{self, Canvas, Frame, Geometry, Path, Program, Stroke};
+use iced::widget::canvas::{self, Canvas, Frame, Geometry, Path, Program, Stroke, Text};
 use iced::{Color, Rectangle, Size, Point};
 
 #[derive(Debug, Clone)]
@@ -31,6 +31,15 @@ impl<Message> Program<Message> for FaceRecognizer {
                 Size::new(face.bbox[2] as f32 * sx, face.bbox[3] as f32 * sy),
             );
             frame.stroke(&path, Stroke { color: Color::from_rgb(1.0, 0.0, 0.0), width: 2.0, ..Stroke::default() });
+            if let Some(name) = &face.name {
+                frame.fill_text(Text {
+                    content: name.clone(),
+                    position: Point::new(face.bbox[0] as f32 * sx, (face.bbox[1] as f32 * sy - 14.0).max(0.0)),
+                    color: Color::from_rgb(1.0, 0.0, 0.0),
+                    size: 16.0,
+                    ..Default::default()
+                });
+            }
         }
         vec![frame.into_geometry()]
     }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1124,6 +1124,9 @@ impl Application for GooglePiczUI {
                 if self.deleting_album.is_some() {
                     return self.update(Message::CancelDeleteAlbum);
                 }
+                if self.editing_face.is_some() {
+                    return self.update(Message::CancelFaceName);
+                }
                 if let ViewState::SelectedPhoto { .. } = &self.state {
                     self.state = ViewState::Grid;
                 }


### PR DESCRIPTION
## Summary
- keep existing face names when re-detecting faces
- run face detection with name preservation during sync
- show face names overlaid on images
- allow escape key to close face name editor
- adjust tests for new API

## Testing
- `cargo test --locked` *(fails: could not build `clang-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_686a915bd678833384e23b9a652f1139