### PR TITLE
Add rpm/AppImage tests and document CI

### DIFF
--- a/docs/RELEASE_ARTIFACTS.md
+++ b/docs/RELEASE_ARTIFACTS.md
@@ -116,11 +116,18 @@ reproducible artifact names across Linux, macOS and Windows.
 ### GitHub Actions
 
 The workflow in `.github/workflows/packager.yml` runs the packager on
-Linux, macOS and Windows. It executes
-`cargo run --package packaging --bin packager` and uploads the resulting
-artifacts from the `target` directory via `upload-artifact`. You can
-download these packages from the workflow run page without building them
-locally.
+Linux, macOS and Windows.
+
+It performs the following steps on each runner:
+
+1. Checkout the repository.
+2. Install the stable Rust toolchain and platform specific utilities.
+3. Run `cargo run --package packaging --bin packager`.
+4. Run `cargo run --package packaging --bin ci_checks` to verify the artifacts.
+5. Upload the generated files from `target/` using `actions/upload-artifact`.
+
+You can download these packages from the workflow run page without building
+them locally.
 
 ## Release Process {#release-process}
 

--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -680,6 +680,54 @@ mod tests {
         std::env::remove_var("LINUX_SIGN_KEY");
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial]
+    fn test_create_linux_package_function_rpm() {
+        use crate::utils::{get_project_root, workspace_version};
+        std::env::set_var("MOCK_COMMANDS", "1");
+        std::env::set_var("LINUX_PACKAGE_FORMAT", "rpm");
+        let root = get_project_root();
+        let rpm_dir = root.join("target/rpmbuild/RPMS");
+        fs::create_dir_all(&rpm_dir).unwrap();
+        fs::write(rpm_dir.join("dummy.rpm"), b"test").unwrap();
+
+        let result = create_linux_package();
+        assert!(result.is_ok());
+
+        let version = workspace_version().unwrap();
+        let rpm = artifact_path(&version);
+        assert!(rpm.exists());
+        fs::remove_file(rpm).unwrap();
+
+        std::env::remove_var("MOCK_COMMANDS");
+        std::env::remove_var("LINUX_PACKAGE_FORMAT");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial]
+    fn test_create_linux_package_function_appimage() {
+        use crate::utils::{get_project_root, workspace_version};
+        std::env::set_var("MOCK_COMMANDS", "1");
+        std::env::set_var("LINUX_PACKAGE_FORMAT", "appimage");
+        let root = get_project_root();
+        let img_dir = root.join("target/appimage");
+        fs::create_dir_all(&img_dir).unwrap();
+        fs::write(img_dir.join("dummy.AppImage"), b"test").unwrap();
+
+        let result = create_linux_package();
+        assert!(result.is_ok());
+
+        let version = workspace_version().unwrap();
+        let img = artifact_path(&version);
+        assert!(img.exists());
+        fs::remove_file(img).unwrap();
+
+        std::env::remove_var("MOCK_COMMANDS");
+        std::env::remove_var("LINUX_PACKAGE_FORMAT");
+    }
+
     #[cfg(target_os = "windows")]
     #[test]
     #[serial]

--- a/packaging/tests/packager_cli.rs
+++ b/packaging/tests/packager_cli.rs
@@ -35,3 +35,36 @@ fn test_packager_cli_format() -> Result<(), Box<dyn std::error::Error>> {
     std::env::remove_var("LINUX_PACKAGE_FORMAT");
     Ok(())
 }
+
+#[test]
+#[serial]
+fn test_packager_cli_appimage() -> Result<(), Box<dyn std::error::Error>> {
+    std::env::set_var("MOCK_COMMANDS", "1");
+    std::env::set_var("LINUX_PACKAGE_FORMAT", "appimage");
+    let root = get_project_root();
+
+    #[cfg(target_os = "linux")]
+    {
+        let img_dir = root.join("target/appimage");
+        fs::create_dir_all(&img_dir)?;
+        fs::write(img_dir.join("dummy.AppImage"), b"test")?;
+    }
+
+    Command::cargo_bin("packager")?
+        .arg("--format")
+        .arg("appimage")
+        .assert()
+        .success();
+
+    #[cfg(target_os = "linux")]
+    {
+        let version = workspace_version()?;
+        let img = artifact_path(&version);
+        assert!(img.exists());
+        fs::remove_file(img)?;
+    }
+
+    std::env::remove_var("MOCK_COMMANDS");
+    std::env::remove_var("LINUX_PACKAGE_FORMAT");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add tests for the rpm and AppImage packaging paths
- expand CLI tests with `--format appimage`
- document the CI workflow steps in `RELEASE_ARTIFACTS.md`

## Testing
- `cargo test -p packaging`

------
https://chatgpt.com/codex/tasks/task_e_686a915f666483338d9828e356c19366