### PR TITLE
Add additional test cases

### DIFF
--- a/app/tests/cli.rs
+++ b/app/tests/cli.rs
@@ -70,3 +70,31 @@ fn sync_cli_search_no_cache() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn sync_cli_create_album_no_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_home = TempDir::new()?;
+    let mut cmd = Command::cargo_bin("sync_cli")?;
+    cmd.args(["create-album", "New"]);
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("HOME", tmp_home.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No cache found"));
+    Ok(())
+}
+
+#[test]
+fn sync_cli_search_albums_no_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_home = TempDir::new()?;
+    let mut cmd = Command::cargo_bin("sync_cli")?;
+    cmd.args(["search-albums", "test"]);
+    cmd.env("MOCK_API_CLIENT", "1");
+    cmd.env("MOCK_KEYRING", "1");
+    cmd.env("HOME", tmp_home.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No cache found"));
+    Ok(())
+}
+

--- a/packaging/tests/installer_artifacts.rs
+++ b/packaging/tests/installer_artifacts.rs
@@ -18,6 +18,8 @@ fn test_linux_installer_artifact_exists() -> Result<(), Box<dyn std::error::Erro
     let version = workspace_version()?;
     let deb = artifact_path(&version);
     assert!(deb.exists());
+    let data = fs::read(&deb)?;
+    assert_eq!(data, b"test");
     fs::remove_file(deb)?;
 
     std::env::remove_var("MOCK_COMMANDS");
@@ -41,6 +43,8 @@ fn test_macos_installer_artifact_exists() -> Result<(), Box<dyn std::error::Erro
     let version = workspace_version()?;
     let dmg = artifact_path(&version);
     assert!(dmg.exists());
+    let data = fs::read(&dmg)?;
+    assert_eq!(data, b"test");
     fs::remove_file(dmg)?;
 
     std::env::remove_var("MOCK_COMMANDS");
@@ -64,6 +68,8 @@ fn test_windows_installer_artifact_exists() -> Result<(), Box<dyn std::error::Er
     create_installer()?;
     let exe = artifact_path(&version);
     assert!(exe.exists());
+    let data = fs::read(&exe)?;
+    assert_eq!(data, b"test");
     fs::remove_file(exe)?;
     fs::remove_file(rel_dir.join("googlepicz.exe"))?;
 

--- a/packaging/tests/package_all.rs
+++ b/packaging/tests/package_all.rs
@@ -50,6 +50,8 @@ fn test_package_all_mock() {
         let version = workspace_version().unwrap();
         let file = artifact_path(&version);
         assert!(file.exists(), "Expected {:?} to exist", file);
+        let data = fs::read(&file).unwrap();
+        assert_eq!(data, b"test");
         fs::remove_file(file).unwrap();
     }
 
@@ -57,6 +59,8 @@ fn test_package_all_mock() {
         let version = workspace_version().unwrap();
         let dmg = artifact_path(&version);
         assert!(dmg.exists(), "Expected {:?} to exist", dmg);
+        let data = fs::read(&dmg).unwrap();
+        assert_eq!(data, b"test");
         fs::remove_file(dmg).unwrap();
     }
 
@@ -64,6 +68,8 @@ fn test_package_all_mock() {
         let version = workspace_version().unwrap();
         let exe = artifact_path(&version);
         assert!(exe.exists(), "Expected {:?} to exist", exe);
+        let data = fs::read(&exe).unwrap();
+        assert_eq!(data, b"test");
         fs::remove_file(exe).unwrap();
     }
 

--- a/packaging/tests/packager_cli.rs
+++ b/packaging/tests/packager_cli.rs
@@ -28,6 +28,8 @@ fn test_packager_cli_format() -> Result<(), Box<dyn std::error::Error>> {
         let version = workspace_version()?;
         let rpm = artifact_path(&version);
         assert!(rpm.exists());
+        let data = fs::read(&rpm)?;
+        assert_eq!(data, b"test");
         fs::remove_file(rpm)?;
     }
 

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -42,5 +42,10 @@ name = "face_tagging_e2e"
 path = "tests/face_tagging_e2e.rs"
 harness = false
 
+[[test]]
+name = "face_model_missing_e2e"
+path = "tests/face_model_missing_e2e.rs"
+harness = false
+
 [features]
 trace-spans = []

--- a/tests/e2e/tests/face_model_missing_e2e.rs
+++ b/tests/e2e/tests/face_model_missing_e2e.rs
@@ -1,0 +1,39 @@
+use face_recognition::{FaceRecognizer, FaceRecognitionError};
+use api_client::{MediaItem, MediaMetadata};
+use tempfile::TempDir;
+use base64::Engine;
+
+const SAMPLE_IMAGE_B64: &str = include_str!("../../face_recognition/tests/face_image.b64");
+
+#[tokio::main]
+async fn main() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("OPENCV_HAARCASCADE_PATH", "/nonexistent.xml");
+
+    let engine = base64::engine::general_purpose::STANDARD;
+    let data = engine.decode(SAMPLE_IMAGE_B64.replace('\n', "").as_bytes()).expect("decode");
+
+    let dir = TempDir::new().expect("dir");
+    let img_path = dir.path().join("face.jpg");
+    std::fs::write(&img_path, &data).expect("write image");
+
+    let item = MediaItem {
+        id: "1".into(),
+        description: None,
+        product_url: String::new(),
+        base_url: format!("file://{}", img_path.display()),
+        mime_type: "image/jpeg".into(),
+        media_metadata: MediaMetadata {
+            creation_time: "2024-01-01T00:00:00Z".into(),
+            width: "200".into(),
+            height: "200".into(),
+            video: None,
+        },
+        filename: "face.jpg".into(),
+    };
+
+    let recognizer = FaceRecognizer::new();
+    let result = recognizer.detect_faces(&item);
+    assert!(matches!(result, Err(FaceRecognitionError::ModelNotFound(_))));
+}

--- a/tests/e2e/video_playback.rs
+++ b/tests/e2e/video_playback.rs
@@ -28,3 +28,19 @@ async fn test_invalid_video_errors() {
     let url = gstreamer_iced::reexport::url::Url::from_file_path(&path).unwrap();
     assert!(GstreamerIcedBase::new_url(&url, false).is_err());
 }
+
+#[tokio::test]
+async fn test_sample_video_end_message() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("videos")
+        .join("sample.mp4");
+    let url = gstreamer_iced::reexport::url::Url::from_file_path(&path).unwrap();
+    let mut player = match GstreamerIcedBase::new_url(&url, false) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let _ = player.update(GStreamerMessage::PlayStatusChanged(PlayStatus::Playing));
+    let res = player.update(GStreamerMessage::BusGoToEnd);
+    assert!(res.is_ok());
+}


### PR DESCRIPTION
## Summary
- extend CLI tests for search and album commands
- add video stop and missing model tests to e2e suite
- verify artifact contents in packaging tests

## Testing
- `cargo test -p packaging`

------
https://chatgpt.com/codex/tasks/task_e_686a916122c883338b2a9fb424e05d1c