### PR TITLE
Update user docs for new settings

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -58,3 +58,7 @@
 - Consolidated configuration documentation. `docs/CONFIGURATION.md` now lists all environment variables and `AppConfig` options.
 - Removed duplicated setup instructions from `README.md` and `docs/DOCUMENTATION.md`.
 - Simplified goals section in `DOCUMENTATION.md` and referenced the README.
+
+## 2025-07-07
+- Documented the new `preload_threads` option in `docs/USER_GUIDE.md` and sample config.
+- Updated `docs/targetpicture.md` to mention UI screenshots and highlight `preload_threads`.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -11,6 +11,7 @@ The application reads `AppConfig` from `~/.googlepicz/config`. Available keys ar
 | `log_level` | `String` | `"info"` | Verbosity of application logging. |
 | `oauth_redirect_port` | `u16` | `8080` | Port used during the OAuth flow. |
 | `thumbnails_preload` | `usize` | `20` | Number of thumbnails to preload. |
+| `preload_threads` | `usize` | `4` | Number of worker threads for preloading thumbnails. |
 | `sync_interval_minutes` | `u64` | `5` | Minutes between automatic sync runs. |
 | `cache_path` | `String` | `"~/.googlepicz"` | Location for cache and logs. |
 | `debug_console` | `bool` | `false` | Enable the Tokio console subscriber. |
@@ -24,6 +25,7 @@ Create `~/.googlepicz/config` and adjust the values as needed:
 log_level = "debug"
 oauth_redirect_port = 9000
 thumbnails_preload = 30
+preload_threads = 4
 sync_interval_minutes = 15
 cache_path = "/tmp/googlepicz"
 debug_console = false

--- a/docs/targetpicture.md
+++ b/docs/targetpicture.md
@@ -43,15 +43,15 @@ The project is structured as a Rust workspace with the following modules (crates
 - Scaffold scripts for boilerplate code generation.
 - CI job (GitHub Actions) for cross-compilation and packaging.
 - Hot-reloading for UI prototyping.
-
 ## Delivery & Quality Assurance
-- Sample screenshots generated in CI.
+- Sample screenshots generated in CI and stored in `docs/screenshots`.
 - End-to-end smoke tests: Authentication → Album list → Thumbnail display.
 - Generation of ready-to-distribute installer artifacts for both platforms.
 
 ## Configuration Highlights
 The application reads `AppConfig` from `~/.googlepicz/config`. Important options
 include `cache_path` for the data directory, `debug_console` to enable Tokio's
-console subscriber, `trace_spans` for detailed profiling and `detect_faces` to run face detection. OAuth tokens can be
+console subscriber, `trace_spans` for detailed profiling, `preload_threads` to
+control thumbnail workers and `detect_faces` to run face detection. OAuth tokens can be
 stored in the file system by compiling with the `auth/file-store` feature and
 starting the tools with `--use-file-store` or `USE_FILE_STORE=1`.


### PR DESCRIPTION
## Summary
- document `preload_threads` in USER_GUIDE
- mention screenshots and new option in targetpicture
- add changelog entry

## Testing
- `cargo fmt -- --check` *(fails: rustfmt component missing)*
- `cargo clippy --all -- -D warnings` *(fails: clippy component missing)*
- `cargo test --all` *(fails: could not find `llvm-config` for clang-sys build)*
- `cargo bench --bench cache_bench -p cache -- --test` *(fails: panic during build)*

------
https://chatgpt.com/codex/tasks/task_e_686a916375f48333b0b8f73c527c4bd6