### PR TITLE
Refactor UI components into separate modules

### DIFF
--- a/ui/src/album_dialogs.rs
+++ b/ui/src/album_dialogs.rs
@@ -1,0 +1,90 @@
+use iced::widget::{button, column, row, text, text_input};
+
+use crate::{style, Icon, MaterialSymbol, Message};
+use crate::style::Palette;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlbumOption {
+    pub id: String,
+    pub title: String,
+}
+
+impl std::fmt::Display for AlbumOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.title)
+    }
+}
+
+pub fn create_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>> {
+    if ui.creating_album {
+        Some(
+            column![
+                text_input("Album title", &ui.new_album_title)
+                    .style(style::text_input_basic())
+                    .on_input(Message::AlbumTitleChanged),
+                row![
+                    button(Icon::new(MaterialSymbol::Add).color(Palette::ON_PRIMARY))
+                        .style(style::button_primary())
+                        .on_press(Message::CreateAlbum),
+                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_PRIMARY))
+                        .style(style::button_primary())
+                        .on_press(Message::CancelCreateAlbum),
+                ]
+                .spacing(10),
+            ]
+            .spacing(10)
+            .into(),
+        )
+    } else {
+        None
+    }
+}
+
+pub fn rename_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>> {
+    if ui.renaming_album.is_some() {
+        Some(
+            column![
+                text_input("New title", &ui.rename_album_title)
+                    .style(style::text_input_basic())
+                    .on_input(Message::RenameAlbumTitleChanged),
+                row![
+                    button(Icon::new(MaterialSymbol::Save).color(Palette::ON_PRIMARY))
+                        .style(style::button_primary())
+                        .on_press(Message::ConfirmRenameAlbum),
+                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_PRIMARY))
+                        .style(style::button_primary())
+                        .on_press(Message::CancelRenameAlbum),
+                ]
+                .spacing(10),
+            ]
+            .spacing(10)
+            .into(),
+        )
+    } else {
+        None
+    }
+}
+
+pub fn delete_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>> {
+    if ui.deleting_album.is_some() {
+        Some(
+            column![
+                text("Delete album?").size(16),
+                row![
+                    button(Icon::new(MaterialSymbol::Delete).color(Palette::ON_PRIMARY))
+                        .style(style::button_primary())
+                        .on_press(Message::ConfirmDeleteAlbum),
+                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_PRIMARY))
+                        .style(style::button_primary())
+                        .on_press(Message::CancelDeleteAlbum),
+                ]
+                .spacing(10),
+            ]
+            .spacing(10)
+            .into(),
+        )
+    } else {
+        None
+    }
+}
+

--- a/ui/src/search.rs
+++ b/ui/src/search.rs
@@ -1,0 +1,116 @@
+use chrono::{DateTime, Utc};
+use iced::widget::{button, checkbox, pick_list, row, text_input};
+
+use crate::{style, Message};
+use crate::style::Palette;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchMode {
+    Filename,
+    Description,
+    Text,
+    Favoriten,
+    DateRange,
+    MimeType,
+    CameraModel,
+    CameraMake,
+}
+
+impl SearchMode {
+    pub const ALL: [SearchMode; 8] = [
+        SearchMode::Filename,
+        SearchMode::Description,
+        SearchMode::Text,
+        SearchMode::Favoriten,
+        SearchMode::DateRange,
+        SearchMode::MimeType,
+        SearchMode::CameraModel,
+        SearchMode::CameraMake,
+    ];
+
+    pub fn placeholder(self) -> &'static str {
+        match self {
+            SearchMode::Filename => "Filename",
+            SearchMode::Description => "Description",
+            SearchMode::Text => "Filename or description",
+            SearchMode::Favoriten => "Favorites",
+            SearchMode::MimeType => "Mime type",
+            SearchMode::CameraModel => "Camera model",
+            SearchMode::CameraMake => "Camera make",
+            SearchMode::DateRange => "YYYY-MM-DD..YYYY-MM-DD",
+        }
+    }
+}
+
+impl std::fmt::Display for SearchMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            SearchMode::Filename => "Filename",
+            SearchMode::Description => "Beschreibung",
+            SearchMode::Text => "Dateiname/Beschr.",
+            SearchMode::Favoriten => "Favoriten",
+            SearchMode::DateRange => "Datum von/bis",
+            SearchMode::MimeType => "Dateityp",
+            SearchMode::CameraModel => "Kamera-Modell",
+            SearchMode::CameraMake => "Kamera-Hersteller",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+pub(crate) fn parse_date_query(query: &str) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    use chrono::{NaiveDate, TimeZone};
+    if let Some(idx) = query.find("..") {
+        let start_str = &query[..idx];
+        let end_str = &query[idx + 2..];
+        if let (Ok(s), Ok(e)) = (
+            NaiveDate::parse_from_str(start_str, "%Y-%m-%d"),
+            NaiveDate::parse_from_str(end_str, "%Y-%m-%d"),
+        ) {
+            let start = Utc.from_utc_datetime(&s.and_hms_opt(0, 0, 0)?);
+            let end = Utc.from_utc_datetime(&e.and_hms_opt(23, 59, 59)?);
+            return Some((start, end));
+        }
+    } else if let Ok(d) = NaiveDate::parse_from_str(query, "%Y-%m-%d") {
+        let start = Utc.from_utc_datetime(&d.and_hms_opt(0, 0, 0)?);
+        let end = Utc.from_utc_datetime(&d.and_hms_opt(23, 59, 59)?);
+        return Some((start, end));
+    }
+    None
+}
+
+pub(crate) fn parse_single_date(query: &str, end: bool) -> Option<DateTime<Utc>> {
+    use chrono::{NaiveDate, TimeZone};
+    if let Ok(d) = NaiveDate::parse_from_str(query, "%Y-%m-%d") {
+        let nd = if end { d.and_hms_opt(23, 59, 59)? } else { d.and_hms_opt(0, 0, 0)? };
+        return Some(Utc.from_utc_datetime(&nd));
+    }
+    None
+}
+
+pub fn view<'a>(ui: &crate::GooglePiczUI) -> iced::Element<'a, Message> {
+    row![
+        text_input(ui.search_mode.placeholder(), &ui.search_query)
+            .style(style::text_input_basic())
+            .on_input(Message::SearchInputChanged),
+        text_input("Camera", &ui.search_camera)
+            .style(style::text_input_basic())
+            .on_input(Message::SearchCameraChanged),
+        text_input("From", &ui.search_start)
+            .style(style::text_input_basic())
+            .on_input(Message::SearchStartChanged),
+        text_input("To", &ui.search_end)
+            .style(style::text_input_basic())
+            .on_input(Message::SearchEndChanged),
+        checkbox("Fav", ui.search_favorite, Message::SearchFavoriteToggled)
+            .style(style::checkbox_primary()),
+        pick_list(&SearchMode::ALL[..], Some(ui.search_mode), Message::SearchModeChanged),
+        button("Search")
+            .style(style::button_primary())
+            .on_press(Message::PerformSearch)
+    ]
+    .spacing(Palette::SPACING)
+    .align_items(iced::Alignment::Center)
+    .into()
+}
+

--- a/ui/src/settings.rs
+++ b/ui/src/settings.rs
@@ -1,0 +1,62 @@
+use iced::widget::{button, checkbox, column, pick_list, row, text, text_input};
+
+use crate::{style, Message};
+use crate::style::Palette;
+
+pub const LOG_LEVELS: [&str; 5] = ["trace", "debug", "info", "warn", "error"];
+
+pub fn dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>> {
+    if ui.settings_open {
+        Some(
+            column![
+                text("Settings").size(16),
+                pick_list(
+                    &LOG_LEVELS[..],
+                    Some(ui.settings_log_level.as_str()),
+                    |v| Message::SettingsLogLevelChanged(v.to_string()),
+                ),
+                text_input("OAuth port", &ui.settings_oauth_port)
+                    .style(style::text_input_basic())
+                    .on_input(Message::SettingsOauthPortChanged),
+                text_input("Thumbs preload", &ui.settings_thumbnails_preload)
+                    .style(style::text_input_basic())
+                    .on_input(Message::SettingsThumbsPreloadChanged),
+                text_input("Preload threads", &ui.settings_preload_threads)
+                    .style(style::text_input_basic())
+                    .on_input(Message::SettingsPreloadThreadsChanged),
+                text_input("Sync interval", &ui.settings_sync_interval)
+                    .style(style::text_input_basic())
+                    .on_input(Message::SettingsSyncIntervalChanged),
+                checkbox(
+                    "Debug console",
+                    ui.settings_debug_console,
+                    Message::SettingsDebugConsoleToggled,
+                )
+                .style(style::checkbox_primary()),
+                checkbox(
+                    "Trace spans",
+                    ui.settings_trace_spans,
+                    Message::SettingsTraceSpansToggled,
+                )
+                .style(style::checkbox_primary()),
+                text_input("Cache path", &ui.settings_cache_path)
+                    .style(style::text_input_basic())
+                    .on_input(Message::SettingsCachePathChanged),
+                row![
+                    button("Save")
+                        .style(style::button_primary())
+                        .on_press(Message::SaveSettings),
+                    button("Cancel")
+                        .style(style::button_primary())
+                        .on_press(Message::CloseSettings),
+                ]
+                .spacing(10),
+            ]
+            .spacing(10)
+            .into(),
+        )
+    } else {
+        None
+    }
+}
+


### PR DESCRIPTION
## Summary
- factor out album dialogs, search bar and settings dialog into standalone files
- re-export SearchMode and AlbumOption from new modules
- simplify `lib.rs` by using the new helpers

## Testing
- `cargo check` *(fails: glib-sys missing system library)*
- `cargo test` *(fails: clang-sys missing LLVM libraries)*

------
https://chatgpt.com/codex/tasks/task_e_686a91612b1c8333be69aba72f5a318a