### PR TITLE
Add advanced search filters

### DIFF
--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -138,6 +138,9 @@ enum Commands {
         /// Filter by camera model
         #[arg(long)]
         camera_model: Option<String>,
+        /// Filter by camera make
+        #[arg(long)]
+        camera_make: Option<String>,
         /// Filter by MIME type
         #[arg(long)]
         mime_type: Option<String>,
@@ -373,6 +376,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             start,
             end,
             camera_model,
+            camera_make,
             mime_type,
             favorite,
         } => {
@@ -387,26 +391,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let end_dt = end
                 .as_deref()
                 .and_then(|s| parse_date(s, true));
-            let base_items = if let Some(model) = camera_model.as_deref() {
-                cache.get_media_items_by_camera_model(model)?
-            } else if let Some(mime) = mime_type.as_deref() {
-                cache.get_media_items_by_mime_type(mime)?
-            } else if favorite {
-                cache.get_media_items_by_favorite(true)?
-            } else {
-                cache.get_media_items_by_text(&query)?
-            };
-
-            let mut items = cache.query_media_items(
+            let items = cache.query_media_items(
                 camera_model.as_deref(),
+                camera_make.as_deref(),
                 start_dt,
                 end_dt,
                 if favorite { Some(true) } else { None },
+                mime_type.as_deref(),
                 Some(&query),
             )?;
-            if camera_model.is_some() || mime_type.is_some() || favorite {
-                items.retain(|i| base_items.iter().any(|b| b.id == i.id));
-            }
             let max = limit.unwrap_or(10);
             for item in items.iter().take(max) {
                 println!("{} - {}", item.id, item.filename);

--- a/cache/benches/cache_bench.rs
+++ b/cache/benches/cache_bench.rs
@@ -276,7 +276,15 @@ fn bench_text_query_general_1k(c: &mut Criterion) {
     c.bench_function("query_text_1k", |b| {
         b.iter(|| {
             let _ = cache
-                .query_media_items(None, None, None, None, Some("foo"))
+                .query_media_items(
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("foo"),
+                )
                 .unwrap();
         })
     });
@@ -295,7 +303,15 @@ fn bench_text_query_general_10k(c: &mut Criterion) {
     c.bench_function("query_text_10k", |b| {
         b.iter(|| {
             let _ = cache
-                .query_media_items(None, None, None, None, Some("foo"))
+                .query_media_items(
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("foo"),
+                )
                 .unwrap();
         })
     });
@@ -314,7 +330,15 @@ fn bench_text_query_general_100k(c: &mut Criterion) {
     c.bench_function("query_text_100k", |b| {
         b.iter(|| {
             let _ = cache
-                .query_media_items(None, None, None, None, Some("foo"))
+                .query_media_items(
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("foo"),
+                )
                 .unwrap();
         })
     });
@@ -333,7 +357,15 @@ fn bench_text_query_general_200k(c: &mut Criterion) {
     c.bench_function("query_text_200k", |b| {
         b.iter(|| {
             let _ = cache
-                .query_media_items(None, None, None, None, Some("foo"))
+                .query_media_items(
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("foo"),
+                )
                 .unwrap();
         })
     });

--- a/cache/benches/real_queries.rs
+++ b/cache/benches/real_queries.rs
@@ -45,7 +45,15 @@ fn bench_real_query(c: &mut Criterion) {
     c.bench_function("real_query", |b| {
         b.iter(|| {
             let _ = cache
-                .query_media_items(Some("EOS"), Some(start), Some(end), None, Some("sample"))
+                .query_media_items(
+                    Some("EOS"),
+                    None,
+                    Some(start),
+                    Some(end),
+                    None,
+                    None,
+                    Some("sample"),
+                )
                 .unwrap();
         })
     });

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -440,9 +440,11 @@ impl CacheManager {
     pub fn query_media_items(
         &self,
         camera_model: Option<&str>,
+        camera_make: Option<&str>,
         start: Option<DateTime<Utc>>,
         end: Option<DateTime<Utc>>,
         favorite: Option<bool>,
+        mime_type: Option<&str>,
         text: Option<&str>,
     ) -> Result<Vec<api_client::MediaItem>, CacheError> {
         let conn = self.lock_conn()?;
@@ -451,10 +453,12 @@ impl CacheManager {
             "FROM media_items m ",
             "JOIN media_metadata md ON m.id = md.media_item_id ",
             "WHERE (?1 IS NULL OR md.camera_model = ?1) ",
-            "AND (?2 IS NULL OR md.creation_time >= ?2) ",
-            "AND (?3 IS NULL OR md.creation_time <= ?3) ",
-            "AND (?4 IS NULL OR m.is_favorite = ?4) ",
-            "AND (?5 IS NULL OR m.filename LIKE ?5 OR m.description LIKE ?5)"
+            "AND (?2 IS NULL OR md.camera_make = ?2) ",
+            "AND (?3 IS NULL OR md.creation_time >= ?3) ",
+            "AND (?4 IS NULL OR md.creation_time <= ?4) ",
+            "AND (?5 IS NULL OR m.is_favorite = ?5) ",
+            "AND (?6 IS NULL OR m.mime_type = ?6) ",
+            "AND (?7 IS NULL OR m.filename LIKE ?7 OR m.description LIKE ?7)"
         );
         let mut stmt = conn
             .prepare_cached(sql)
@@ -467,9 +471,11 @@ impl CacheManager {
             .query_map(
                 params![
                     camera_model,
+                    camera_make,
                     start.map(|s| s.timestamp()),
                     end.map(|e| e.timestamp()),
                     fav_val,
+                    mime_type,
                     like_pattern.as_deref()
                 ],
                 |row| {
@@ -1394,18 +1400,22 @@ impl CacheManager {
     pub async fn query_media_items_async(
         &self,
         camera_model: Option<String>,
+        camera_make: Option<String>,
         start: Option<DateTime<Utc>>,
         end: Option<DateTime<Utc>>,
         favorite: Option<bool>,
+        mime_type: Option<String>,
         text: Option<String>,
     ) -> Result<Vec<api_client::MediaItem>, CacheError> {
         let this = self.clone();
         tokio::task::spawn_blocking(move || {
             this.query_media_items(
                 camera_model.as_deref(),
+                camera_make.as_deref(),
                 start,
                 end,
                 favorite,
+                mime_type.as_deref(),
                 text.as_deref(),
             )
         })
@@ -1655,7 +1665,15 @@ mod tests {
         let start = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
         let end = Utc.with_ymd_and_hms(2023, 1, 31, 23, 59, 59).unwrap();
         let items = cache
-            .query_media_items(Some("EOS"), Some(start), Some(end), Some(true), None)
+            .query_media_items(
+                Some("EOS"),
+                None,
+                Some(start),
+                Some(end),
+                Some(true),
+                None,
+                None,
+            )
             .expect("query");
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, item1.id);

--- a/cache/tests/cache_manager.rs
+++ b/cache/tests/cache_manager.rs
@@ -302,7 +302,15 @@ fn test_query_media_items_combined() {
     let start = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
     let end = Utc.with_ymd_and_hms(2023, 1, 31, 23, 59, 59).unwrap();
     let results = cm
-        .query_media_items(Some("EOS"), Some(start), Some(end), Some(true), None)
+        .query_media_items(
+            Some("EOS"),
+            None,
+            Some(start),
+            Some(end),
+            Some(true),
+            None,
+            None,
+        )
         .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id, item1.id);
@@ -331,7 +339,15 @@ fn test_query_media_items_text_date_fav() {
     let start = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
     let end = Utc.with_ymd_and_hms(2023, 1, 31, 23, 59, 59).unwrap();
     let results = cm
-        .query_media_items(None, Some(start), Some(end), Some(true), Some("holiday"))
+        .query_media_items(
+            None,
+            None,
+            Some(start),
+            Some(end),
+            Some(true),
+            None,
+            Some("holiday"),
+        )
         .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id, item1.id);


### PR DESCRIPTION
## Summary
- extend cache query API with camera make and MIME type filters
- add camera make and mime type options to UI search and CLI search
- use pick lists for camera make and mime type in UI

## Testing
- `cargo test --quiet` *(fails: could not download clang-sys build dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686a915851988333b9b1d427bac40b3d