### PR TITLE
Add progress/error status channel

### DIFF
--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -254,7 +254,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             });
             syncer
-                .sync_media_items(Some(tx), Some(err_tx), None, None)
+                .sync_media_items(Some(tx), Some(err_tx), None, None, None)
                 .await?;
         }
         Commands::Status => {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -161,6 +161,7 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
                         Some(err_tx.clone()),
                         Some(tx.clone()),
                         Some(err_tx.clone()),
+                        Some(status_tx.clone()),
                     )
                     .await
                 {
@@ -178,6 +179,7 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
                     Some(status_tx.clone()),
                     Some(tx.clone()),
                     Some(err_tx.clone()),
+                    Some(status_tx.clone()),
                 )
             } else {
                 error!("❌ Cannot start periodic sync without a valid token");
@@ -188,6 +190,7 @@ async fn main_inner(cfg: config::AppConfig) -> Result<(), Box<dyn std::error::Er
                     Some(status_tx.clone()),
                     Some(tx.clone()),
                     Some(err_tx.clone()),
+                    Some(status_tx.clone()),
                 )
             };
 

--- a/sync/benches/overall.rs
+++ b/sync/benches/overall.rs
@@ -31,7 +31,7 @@ fn bench_sync(c: &mut Criterion) {
             std::env::set_var("GOOGLE_CLIENT_SECRET", "secret");
             let tmp = NamedTempFile::new().unwrap();
             let mut syncer = Syncer::new(tmp.path()).await.unwrap();
-            syncer.sync_media_items(None, None, None, None).await.unwrap();
+            syncer.sync_media_items(None, None, None, None, None).await.unwrap();
         })
     });
 }

--- a/sync/tests/abort_restart.rs
+++ b/sync/tests/abort_restart.rs
@@ -30,6 +30,7 @@ async fn test_periodic_sync_abort_and_restart() {
                 None,
                 None,
                 None,
+                None,
             );
             advance(Duration::from_secs(40)).await; // enough for 5 failures
             let result = handle.await.unwrap();
@@ -52,6 +53,7 @@ async fn test_periodic_sync_abort_and_restart() {
                 Duration::from_secs(1),
                 p_tx2,
                 e_tx2,
+                None,
                 None,
                 None,
                 None,

--- a/sync/tests/error_reporting.rs
+++ b/sync/tests/error_reporting.rs
@@ -21,7 +21,7 @@ async fn test_periodic_sync_reports_error() {
             std::env::remove_var("MOCK_API_CLIENT");
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
-            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None, None);
+            let (handle, shutdown) = syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None, None, None);
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));
             let retry = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
@@ -66,7 +66,7 @@ async fn test_periodic_sync_progress_send_failure_forwarded() {
             let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
             let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
             let (handle, shutdown) =
-                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None, None);
+                syncer.start_periodic_sync(Duration::from_millis(10), prog_tx, err_tx, None, None, None, None, None);
             // consume the Started event then drop receiver to cause send failure later
             let start = timeout(Duration::from_secs(5), prog_rx.recv()).await.unwrap();
             assert!(matches!(start, Some(SyncProgress::Started)));

--- a/sync/tests/repeated_failures.rs
+++ b/sync/tests/repeated_failures.rs
@@ -29,6 +29,8 @@ async fn test_periodic_sync_repeated_failures_reported() {
                 Some(status_tx),
                 None,
                 None,
+                None,
+                None,
             );
             let first = timeout(Duration::from_secs(5), status_rx.recv()).await.unwrap().unwrap();
             let second = timeout(Duration::from_secs(5), status_rx.recv()).await.unwrap().unwrap();

--- a/sync/tests/sync_flow.rs
+++ b/sync/tests/sync_flow.rs
@@ -15,7 +15,7 @@ async fn test_sync_flow_mock() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut syncer = Syncer::new(file.path()).await.unwrap();
     syncer
-        .sync_media_items(Some(tx), None, None, None)
+        .sync_media_items(Some(tx), None, None, None, None)
         .await
         .unwrap();
     match rx.recv().await {

--- a/sync/tests/sync_media_items_error.rs
+++ b/sync/tests/sync_media_items_error.rs
@@ -19,7 +19,7 @@ async fn test_sync_media_items_reports_error() {
     let (prog_tx, mut prog_rx) = mpsc::unbounded_channel();
     let (err_tx, mut err_rx) = mpsc::unbounded_channel::<SyncTaskError>();
     let result = syncer
-        .sync_media_items(Some(prog_tx), Some(err_tx), None, None)
+        .sync_media_items(Some(prog_tx), Some(err_tx), None, None, None)
         .await;
     assert!(result.is_err());
     // ensure error forwarded

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -306,6 +306,14 @@ impl GooglePiczUI {
         self.albums.len()
     }
 
+    pub fn synced(&self) -> u64 {
+        self.synced
+    }
+
+    pub fn sync_status_text(&self) -> String {
+        self.sync_status.clone()
+    }
+
     pub fn renaming_album(&self) -> Option<String> {
         self.renaming_album.clone()
     }
@@ -918,6 +926,12 @@ impl Application for GooglePiczUI {
                     self.syncing = true;
                 } else if message.contains("Sync completed") {
                     self.syncing = false;
+                } else if let Some(rest) = message.strip_prefix("Synced ") {
+                    if let Some(num_str) = rest.split_whitespace().next() {
+                        if let Ok(count) = num_str.parse::<u64>() {
+                            self.synced = count;
+                        }
+                    }
                 }
             },
             Message::SyncError(err_msg) => {

--- a/ui/tests/ui_state.rs
+++ b/ui/tests/ui_state.rs
@@ -265,3 +265,17 @@ fn test_escape_closes_photo() {
     assert_eq!(ui.state_debug(), "Grid");
 }
 
+#[test]
+#[serial]
+fn test_sync_status_updated_progress() {
+    let dir = tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
+    std::fs::create_dir_all(dir.path().join(".googlepicz")).unwrap();
+
+    let (mut ui, _) = GooglePiczUI::new((None, None, None, 0, dir.path().join(".googlepicz")));
+    let now = Utc::now();
+    ui.update(Message::SyncStatusUpdated(now, "Synced 10 items".into()));
+    assert_eq!(ui.synced(), 10);
+    assert_eq!(ui.sync_status_text(), "Synced 10 items");
+}
+


### PR DESCRIPTION
## Summary
- allow sync tasks to forward progress and errors as `SyncTaskError` via new UI status channel
- parse status messages for progress updates in the UI
- expose progress getters and test new status handling
- adapt CLI, benches and tests for new parameters

## Testing
- `cargo test --all --quiet` *(fails: couldn't find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686a9caaed48833398b8167d1afbe0ab