### PR TITLE
Update UI to use Material design theme

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -57,19 +57,6 @@ use tempfile::TempPath;
 const ERROR_DISPLAY_DURATION: Duration = Duration::from_secs(5);
 const PAGE_SIZE: usize = 40;
 
-fn error_container_style() -> iced::theme::Container {
-    iced::theme::Container::Custom(Box::new(|_theme: &Theme| Appearance {
-        text_color: Some(Palette::ERROR),
-        background: Some(Color { a: 1.0, ..Palette::ERROR }.into()),
-        border: Border {
-            color: Palette::ERROR,
-            width: 1.0,
-            radius: 2.0.into(),
-        },
-        shadow: Default::default(),
-    }))
-}
-
 #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(progress, errors)))]
 pub fn run(
     progress: Option<mpsc::UnboundedReceiver<SyncProgress>>,
@@ -547,6 +534,10 @@ impl Application for GooglePiczUI {
 
     fn title(&self) -> String {
         String::from("GooglePicz - Google Photos Manager")
+    }
+
+    fn theme(&self) -> Theme {
+        style::material_theme()
     }
 
     #[cfg_attr(feature = "trace-spans", tracing::instrument(skip(self)))]
@@ -1450,12 +1441,14 @@ impl Application for GooglePiczUI {
                 &self.camera_make_options,
                 self.search_camera_make.clone(),
                 Message::SearchCameraMakeChanged,
-            ),
+            )
+            .style(style::pick_list_primary()),
             pick_list(
                 &self.mime_options,
                 self.search_mime.clone(),
                 Message::SearchMimeChanged,
-            ),
+            )
+            .style(style::pick_list_primary()),
             text_input("From", &self.search_start)
                 .style(style::text_input_basic())
                 .on_input(Message::SearchStartChanged),
@@ -1468,7 +1461,8 @@ impl Application for GooglePiczUI {
                 &SearchMode::ALL[..],
                 Some(self.search_mode),
                 Message::SearchModeChanged,
-            ),
+            )
+            .style(style::pick_list_primary()),
             button("Search")
                 .style(style::button_primary())
                 .on_press(Message::PerformSearch)
@@ -1540,7 +1534,7 @@ impl Application for GooglePiczUI {
                 scrollable(list).height(Length::Fixed(100.0))
             ]
             .spacing(5);
-            Some(container(banner).style(error_container_style()).padding(10).width(Length::Fill))
+            Some(container(banner).style(style::error_container()).padding(10).width(Length::Fill))
         };
 
         let album_dialog = album_dialogs::create_dialog(self);
@@ -1700,6 +1694,7 @@ impl Application for GooglePiczUI {
                         self.assign_selection.clone(),
                         Message::AlbumPicked
                     )
+                    .style(style::pick_list_primary())
                 ];
                 #[cfg(feature = "gstreamer")]
                 if photo.mime_type.starts_with("video/") {

--- a/ui/src/search.rs
+++ b/ui/src/search.rs
@@ -104,7 +104,8 @@ pub fn view<'a>(ui: &crate::GooglePiczUI) -> iced::Element<'a, Message> {
             .on_input(Message::SearchEndChanged),
         checkbox("Fav", ui.search_favorite, Message::SearchFavoriteToggled)
             .style(style::checkbox_primary()),
-        pick_list(&SearchMode::ALL[..], Some(ui.search_mode), Message::SearchModeChanged),
+        pick_list(&SearchMode::ALL[..], Some(ui.search_mode), Message::SearchModeChanged)
+            .style(style::pick_list_primary()),
         button("Search")
             .style(style::button_primary())
             .on_press(Message::PerformSearch)

--- a/ui/src/settings.rs
+++ b/ui/src/settings.rs
@@ -14,7 +14,8 @@ pub fn dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>
                     &LOG_LEVELS[..],
                     Some(ui.settings_log_level.as_str()),
                     |v| Message::SettingsLogLevelChanged(v.to_string()),
-                ),
+                )
+                .style(style::pick_list_primary()),
                 text_input("OAuth port", &ui.settings_oauth_port)
                     .style(style::text_input_basic())
                     .on_input(Message::SettingsOauthPortChanged),

--- a/ui/src/style.rs
+++ b/ui/src/style.rs
@@ -5,7 +5,7 @@
 //! application keeps a consistent Material look.
 
 use iced::{Color, Border};
-use iced::widget::{self, button, container, text_input, checkbox, slider};
+use iced::widget::{self, button, container, text_input, checkbox, slider, pick_list, menu};
 use iced::theme;
 
 /// Material color palette
@@ -14,6 +14,8 @@ pub struct Palette;
 impl Palette {
     pub const PRIMARY: Color = Color { r: 0.25, g: 0.32, b: 0.71, a: 1.0 }; // Indigo 700
     pub const ON_PRIMARY: Color = Color::WHITE;
+    pub const BACKGROUND: Color = Color { r: 0.95, g: 0.95, b: 0.95, a: 1.0 };
+    pub const ON_BACKGROUND: Color = Color { r: 0.0, g: 0.0, b: 0.0, a: 1.0 };
     pub const SURFACE: Color = Color { r: 0.98, g: 0.98, b: 0.98, a: 1.0 };
     pub const ON_SURFACE: Color = Color { r: 0.1, g: 0.1, b: 0.1, a: 1.0 };
     pub const ERROR: Color = Color { r: 0.80, g: 0.0, b: 0.0, a: 1.0 };
@@ -134,4 +136,82 @@ impl slider::StyleSheet for SliderPrimary {
 /// Slider styled with the primary color palette.
 pub fn slider_primary() -> theme::Slider {
     theme::Slider::Custom(Box::new(SliderPrimary))
+}
+
+/// Container styling for error banners.
+pub fn error_container() -> theme::Container {
+    theme::Container::Custom(Box::new(|_theme: &iced::Theme| container::Appearance {
+        text_color: Some(Palette::ON_PRIMARY),
+        background: Some(Color { a: 1.0, ..Palette::ERROR }.into()),
+        border: Border {
+            color: Palette::ERROR,
+            width: 1.0,
+            radius: 2.0.into(),
+        },
+        shadow: Default::default(),
+    }))
+}
+
+struct PickListPrimary;
+
+impl pick_list::StyleSheet for PickListPrimary {
+    type Style = Theme;
+
+    fn active(&self, _style: &Self::Style) -> pick_list::Appearance {
+        pick_list::Appearance {
+            text_color: Palette::ON_SURFACE,
+            placeholder_color: Palette::ON_SURFACE,
+            handle_color: Palette::PRIMARY,
+            background: Palette::SURFACE.into(),
+            border: Border {
+                color: Palette::PRIMARY,
+                width: 1.0,
+                radius: 4.0.into(),
+            },
+        }
+    }
+
+    fn hovered(&self, style: &Self::Style) -> pick_list::Appearance {
+        let mut a = self.active(style);
+        a.border.color = Palette::ON_SURFACE;
+        a
+    }
+}
+
+struct MenuPrimary;
+
+impl menu::StyleSheet for MenuPrimary {
+    type Style = Theme;
+
+    fn appearance(&self, _style: &Self::Style) -> menu::Appearance {
+        menu::Appearance {
+            text_color: Palette::ON_SURFACE,
+            background: Palette::SURFACE.into(),
+            border: Border {
+                color: Palette::PRIMARY,
+                width: 1.0,
+                radius: 2.0.into(),
+            },
+            selected_text_color: Palette::ON_PRIMARY,
+            selected_background: Palette::PRIMARY.into(),
+        }
+    }
+}
+
+/// Pick list with Material styling.
+pub fn pick_list_primary() -> theme::PickList {
+    use std::rc::Rc;
+    theme::PickList::Custom(Rc::new(PickListPrimary), Rc::new(MenuPrimary))
+}
+
+/// Global application theme using the Material palette.
+pub fn material_theme() -> iced::Theme {
+    let palette = theme::Palette {
+        background: Palette::BACKGROUND,
+        text: Palette::ON_BACKGROUND,
+        primary: Palette::PRIMARY,
+        success: Color { r: 0.0, g: 0.6, b: 0.2, a: 1.0 },
+        danger: Palette::ERROR,
+    };
+    iced::Theme::custom(String::from("Material"), palette)
 }


### PR DESCRIPTION
## Summary
- define Material color palette and component styles
- provide a global `material_theme` and style helpers
- apply new styles across the UI

## Testing
- `cargo test --workspace --lib --quiet` *(fails: missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a9cab79848333b0b8aa25278df488