### PR TITLE
Add headless screenshot script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,18 @@ jobs:
         run: cargo test -p packaging
       - name: Run CI checks
         run: cargo run --package packaging --bin ci_checks
+      - name: Install screenshot tools
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y imagemagick xvfb
+      - name: Generate UI screenshots
+        if: runner.os == 'Linux'
+        run: ./tests/e2e/generate_screenshots.sh
+      - name: Upload screenshots
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-screenshots
+          path: docs/screenshots
       - name: Upload checksums
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -309,6 +309,20 @@ docker push ghcr.io/christopher-schulze/googlepicz-ci:latest
 
 The GitHub Actions workflow references this image to ensure consistent dependencies across CI runs.
 
+## 📸 Generating UI Screenshots
+
+Sample screenshots of the application are stored in `docs/screenshots`. You can
+regenerate them locally using the helper script:
+
+```bash
+cd tests/e2e
+./generate_screenshots.sh
+```
+
+The script builds the `googlepicz` binary, launches it under `xvfb-run` and
+saves images of the main window and the settings dialog into
+`docs/screenshots`.
+
 ## ⚠️ Note
 This project is under active development. Features and APIs are subject to change. Documentation will be updated as the project evolves.
 The `Changelog.md` file tracks changes over time.

--- a/tests/e2e/generate_screenshots.sh
+++ b/tests/e2e/generate_screenshots.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Directory for resulting screenshots
+OUT_DIR="${1:-$(git rev-parse --show-toplevel)/docs/screenshots}"
+mkdir -p "$OUT_DIR"
+
+# Build release binary
+cargo build --release --package googlepicz
+BIN="target/release/googlepicz"
+
+# Helper to run and capture screenshot
+run_and_capture() {
+  local out_file=$1
+  shift
+  xvfb-run -a "$BIN" "$@" &
+  local pid=$!
+  sleep 5
+  import -window root "$out_file"
+  kill $pid
+  wait $pid 2>/dev/null || true
+}
+
+# Main screen
+run_and_capture "$OUT_DIR/main.png" --sync-interval-minutes 1
+
+# Settings screen
+OPEN_SETTINGS=1 run_and_capture "$OUT_DIR/settings.png" --sync-interval-minutes 1

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -485,6 +485,8 @@ impl Application for GooglePiczUI {
         };
 
         let cfg = AppConfig::load_from(Some(config_path.clone()));
+        let open_settings = std::env::var("OPEN_SETTINGS").unwrap_or_default() == "1";
+
         let app = Self {
             photos: Vec::new(),
             albums: Vec::new(),
@@ -522,7 +524,7 @@ impl Application for GooglePiczUI {
             search_end: String::new(),
             search_favorite: false,
             error_log_path,
-            settings_open: false,
+            settings_open: open_settings,
             config_path,
             settings_log_level: cfg.log_level.clone(),
             settings_cache_path: cfg.cache_path.to_string_lossy().to_string(),


### PR DESCRIPTION
## Summary
- generate screenshots of the UI using xvfb and ImageMagick
- store the screenshots under `docs/screenshots`
- allow opening the settings dialog via `OPEN_SETTINGS` env var
- run screenshot script in CI on Linux
- document how to generate screenshots locally

## Testing
- `cargo test --all` *(fails: couldn't find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686a9caf175883338e9afb058cb5bebc