### PR TITLE
Refine Material style

### DIFF
--- a/ui/src/album_dialogs.rs
+++ b/ui/src/album_dialogs.rs
@@ -20,14 +20,14 @@ pub fn create_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, M
         Some(
             column![
                 text_input("Album title", &ui.new_album_title)
-                    .style(style::text_input_basic())
+                    .style(style::text_input())
                     .on_input(Message::AlbumTitleChanged),
                 row![
                     button(Icon::new(MaterialSymbol::Add).color(Palette::ON_PRIMARY))
                         .style(style::button_primary())
                         .on_press(Message::CreateAlbum),
-                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_PRIMARY))
-                        .style(style::button_primary())
+                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_SECONDARY))
+                        .style(style::button_secondary())
                         .on_press(Message::CancelCreateAlbum),
                 ]
                 .spacing(10),
@@ -45,14 +45,14 @@ pub fn rename_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, M
         Some(
             column![
                 text_input("New title", &ui.rename_album_title)
-                    .style(style::text_input_basic())
+                    .style(style::text_input())
                     .on_input(Message::RenameAlbumTitleChanged),
                 row![
                     button(Icon::new(MaterialSymbol::Save).color(Palette::ON_PRIMARY))
                         .style(style::button_primary())
                         .on_press(Message::ConfirmRenameAlbum),
-                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_PRIMARY))
-                        .style(style::button_primary())
+                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_SECONDARY))
+                        .style(style::button_secondary())
                         .on_press(Message::CancelRenameAlbum),
                 ]
                 .spacing(10),
@@ -74,8 +74,8 @@ pub fn delete_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, M
                     button(Icon::new(MaterialSymbol::Delete).color(Palette::ON_PRIMARY))
                         .style(style::button_primary())
                         .on_press(Message::ConfirmDeleteAlbum),
-                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_PRIMARY))
-                        .style(style::button_primary())
+                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_SECONDARY))
+                        .style(style::button_secondary())
                         .on_press(Message::CancelDeleteAlbum),
                 ]
                 .spacing(10),

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1441,10 +1441,10 @@ impl Application for GooglePiczUI {
             button(Icon::new(MaterialSymbol::Add).color(Palette::ON_PRIMARY)).style(style::button_primary()).on_press(Message::ShowCreateAlbumDialog),
             button(Icon::new(MaterialSymbol::Settings).color(Palette::ON_PRIMARY)).style(style::button_primary()).on_press(Message::ShowSettings),
             text_input(placeholder, &self.search_query)
-                .style(style::text_input_basic())
+                .style(style::text_input())
                 .on_input(Message::SearchInputChanged),
             text_input("Camera", &self.search_camera)
-                .style(style::text_input_basic())
+                .style(style::text_input())
                 .on_input(Message::SearchCameraChanged),
             pick_list(
                 &self.camera_make_options,
@@ -1457,10 +1457,10 @@ impl Application for GooglePiczUI {
                 Message::SearchMimeChanged,
             ),
             text_input("From", &self.search_start)
-                .style(style::text_input_basic())
+                .style(style::text_input())
                 .on_input(Message::SearchStartChanged),
             text_input("To", &self.search_end)
-                .style(style::text_input_basic())
+                .style(style::text_input())
                 .on_input(Message::SearchEndChanged),
             checkbox("Fav", self.search_favorite, Message::SearchFavoriteToggled)
                 .style(style::checkbox_primary()),
@@ -1575,7 +1575,7 @@ impl Application for GooglePiczUI {
                                 .style(style::button_primary())
                                 .on_press(Message::ShowRenameAlbumDialog(album.id.clone(), title.clone())),
                             button(Icon::new(MaterialSymbol::Delete))
-                                .style(style::button_primary())
+                                .style(style::button_secondary())
                                 .on_press(Message::ShowDeleteAlbumDialog(album.id.clone()))
                         ]
                         .spacing(5);
@@ -1637,6 +1637,7 @@ impl Application for GooglePiczUI {
                     let w = photo.media_metadata.width.parse::<u32>().unwrap_or(0);
                     let h = photo.media_metadata.height.parse::<u32>().unwrap_or(0);
                     container(base)
+                        .style(style::card())
                         .width(Length::Fill)
                         .height(Length::Fill)
                         .overlay(FaceRecognizer::new(faces.clone(), w, h).view())
@@ -1660,13 +1661,13 @@ impl Application for GooglePiczUI {
                     let row_elem = if self.editing_face == Some(i) {
                         row![
                             text_input("Name", &self.face_name_input)
-                                .style(style::text_input_basic())
+                                .style(style::text_input())
                                 .on_input(Message::FaceNameChanged),
                             button(Icon::new(MaterialSymbol::Save).color(Palette::ON_PRIMARY))
                                 .style(style::button_primary())
                                 .on_press(Message::SaveFaceName),
-                            button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_PRIMARY))
-                                .style(style::button_primary())
+                            button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_SECONDARY))
+                                .style(style::button_secondary())
                                 .on_press(Message::CancelFaceName)
                         ]
                     } else {
@@ -1766,9 +1767,10 @@ impl Application for GooglePiczUI {
         }
 
         container(base)
+            .style(style::card())
             .width(Length::Fill)
             .height(Length::Fill)
-            .padding(20)
+            .padding(Palette::SPACING)
             .into()
     }
 }

--- a/ui/src/search.rs
+++ b/ui/src/search.rs
@@ -91,16 +91,16 @@ pub(crate) fn parse_single_date(query: &str, end: bool) -> Option<DateTime<Utc>>
 pub fn view<'a>(ui: &crate::GooglePiczUI) -> iced::Element<'a, Message> {
     row![
         text_input(ui.search_mode.placeholder(), &ui.search_query)
-            .style(style::text_input_basic())
+            .style(style::text_input())
             .on_input(Message::SearchInputChanged),
         text_input("Camera", &ui.search_camera)
-            .style(style::text_input_basic())
+            .style(style::text_input())
             .on_input(Message::SearchCameraChanged),
         text_input("From", &ui.search_start)
-            .style(style::text_input_basic())
+            .style(style::text_input())
             .on_input(Message::SearchStartChanged),
         text_input("To", &ui.search_end)
-            .style(style::text_input_basic())
+            .style(style::text_input())
             .on_input(Message::SearchEndChanged),
         checkbox("Fav", ui.search_favorite, Message::SearchFavoriteToggled)
             .style(style::checkbox_primary()),

--- a/ui/src/settings.rs
+++ b/ui/src/settings.rs
@@ -16,16 +16,16 @@ pub fn dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>
                     |v| Message::SettingsLogLevelChanged(v.to_string()),
                 ),
                 text_input("OAuth port", &ui.settings_oauth_port)
-                    .style(style::text_input_basic())
+                    .style(style::text_input())
                     .on_input(Message::SettingsOauthPortChanged),
                 text_input("Thumbs preload", &ui.settings_thumbnails_preload)
-                    .style(style::text_input_basic())
+                    .style(style::text_input())
                     .on_input(Message::SettingsThumbsPreloadChanged),
                 text_input("Preload threads", &ui.settings_preload_threads)
-                    .style(style::text_input_basic())
+                    .style(style::text_input())
                     .on_input(Message::SettingsPreloadThreadsChanged),
                 text_input("Sync interval", &ui.settings_sync_interval)
-                    .style(style::text_input_basic())
+                    .style(style::text_input())
                     .on_input(Message::SettingsSyncIntervalChanged),
                 checkbox(
                     "Debug console",
@@ -40,14 +40,14 @@ pub fn dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>
                 )
                 .style(style::checkbox_primary()),
                 text_input("Cache path", &ui.settings_cache_path)
-                    .style(style::text_input_basic())
+                    .style(style::text_input())
                     .on_input(Message::SettingsCachePathChanged),
                 row![
                     button("Save")
                         .style(style::button_primary())
                         .on_press(Message::SaveSettings),
                     button("Cancel")
-                        .style(style::button_primary())
+                        .style(style::button_secondary())
                         .on_press(Message::CloseSettings),
                 ]
                 .spacing(10),

--- a/ui/src/style.rs
+++ b/ui/src/style.rs
@@ -5,7 +5,7 @@
 //! application keeps a consistent Material look.
 
 use iced::{Color, Border};
-use iced::widget::{self, button, container, text_input, checkbox, slider};
+use iced::widget::{self, button, checkbox, container, slider, text_input};
 use iced::theme;
 
 /// Material color palette
@@ -13,10 +13,15 @@ pub struct Palette;
 
 impl Palette {
     pub const PRIMARY: Color = Color { r: 0.25, g: 0.32, b: 0.71, a: 1.0 }; // Indigo 700
-    pub const ON_PRIMARY: Color = Color::WHITE;
+    pub const SECONDARY: Color = Color { r: 0.96, g: 0.26, b: 0.21, a: 1.0 }; // Red 500
+    pub const BACKGROUND: Color = Color::WHITE;
     pub const SURFACE: Color = Color { r: 0.98, g: 0.98, b: 0.98, a: 1.0 };
-    pub const ON_SURFACE: Color = Color { r: 0.1, g: 0.1, b: 0.1, a: 1.0 };
     pub const ERROR: Color = Color { r: 0.80, g: 0.0, b: 0.0, a: 1.0 };
+
+    pub const ON_PRIMARY: Color = Color::WHITE;
+    pub const ON_SECONDARY: Color = Color::WHITE;
+    pub const ON_BACKGROUND: Color = Color { r: 0.1, g: 0.1, b: 0.1, a: 1.0 };
+    pub const ON_SURFACE: Color = Self::ON_BACKGROUND;
 
     pub const SPACING: u16 = 16;
     pub const ICON_COLOR: Color = Self::ON_SURFACE;
@@ -33,8 +38,18 @@ pub fn button_primary() -> theme::Button {
     }))
 }
 
+/// Style for secondary action buttons.
+pub fn button_secondary() -> theme::Button {
+    theme::Button::Custom(Box::new(|_theme: &iced::Theme| button::Appearance {
+        background: Some(Palette::SECONDARY.into()),
+        border_radius: 4.0,
+        text_color: Palette::ON_SECONDARY,
+        ..Default::default()
+    }))
+}
+
 /// Basic text input styling.
-pub fn text_input_basic() -> theme::TextInput {
+pub fn text_input() -> theme::TextInput {
     theme::TextInput::Custom(Box::new(|_theme: &iced::Theme| text_input::Appearance {
         background: Palette::SURFACE.into(),
         border_radius: 4.0,


### PR DESCRIPTION
## Summary
- expand the color palette and component theme
- rename `text_input_basic` to `text_input`
- add `button_secondary` style and use it for cancel/delete actions
- wrap dialogs in card containers and update main view padding

## Testing
- `cargo test --workspace --no-default-features --features no-gstreamer --quiet` *(fails: couldn't run build script for `clang-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_686aa27f4d2883338368a9f308e61d35