### PR TITLE
Improve face detection handling

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -294,32 +294,25 @@ impl Syncer {
                 if self.detect_faces {
                     let cache = self.cache_manager.clone();
                     let item_clone = item.clone();
+                    let err_tx = error.clone();
                     let ui_err = ui_error.clone();
                     tokio::task::spawn_blocking(move || {
                         let rec = face_recognition::FaceRecognizer::new();
-                        #[cfg(feature = "face_recognition/cache")]
-                        {
-                            if let Err(e) = rec.detect_and_cache_faces(&cache, &item_clone, true) {
-                                if let Some(tx) = &ui_err {
-                                    let _ = tx.send(SyncTaskError::Other {
-                                        code: SyncErrorCode::Other,
-                                        message: format!("Face detection failed: {}", e),
-                                    });
-                                }
-                                tracing::error!(error = ?e, "Face detection failed");
+                        if let Err(e) = rec.detect_and_cache_faces(&cache, &item_clone, true) {
+                            let msg = format!("Face detection failed: {}", e);
+                            if let Some(tx) = &err_tx {
+                                let _ = tx.send(SyncTaskError::Other {
+                                    code: SyncErrorCode::Other,
+                                    message: msg.clone(),
+                                });
                             }
-                        }
-                        #[cfg(not(feature = "face_recognition/cache"))]
-                        {
-                            if let Err(e) = rec.detect_faces(&item_clone) {
-                                if let Some(tx) = &ui_err {
-                                    let _ = tx.send(SyncTaskError::Other {
-                                        code: SyncErrorCode::Other,
-                                        message: format!("Face detection failed: {}", e),
-                                    });
-                                }
-                                tracing::error!(error = ?e, "Face detection failed");
+                            if let Some(tx) = &ui_err {
+                                let _ = tx.send(SyncTaskError::Other {
+                                    code: SyncErrorCode::Other,
+                                    message: msg.clone(),
+                                });
                             }
+                            tracing::error!(error = ?e, "Face detection failed");
                         }
                     })
                     .await

--- a/ui/src/face_recognizer.rs
+++ b/ui/src/face_recognizer.rs
@@ -26,15 +26,16 @@ impl<Message> Program<Message> for FaceRecognizer {
         let sx = bounds.width / self.width.max(1) as f32;
         let sy = bounds.height / self.height.max(1) as f32;
         for face in &self.faces {
+            let (x, y, w, h) = face.rect;
             let path = Path::rectangle(
-                Point::new(face.bbox[0] as f32 * sx, face.bbox[1] as f32 * sy),
-                Size::new(face.bbox[2] as f32 * sx, face.bbox[3] as f32 * sy),
+                Point::new(x as f32 * sx, y as f32 * sy),
+                Size::new(w as f32 * sx, h as f32 * sy),
             );
             frame.stroke(&path, Stroke { color: Color::from_rgb(1.0, 0.0, 0.0), width: 2.0, ..Stroke::default() });
             if let Some(name) = &face.name {
                 frame.fill_text(Text {
                     content: name.clone(),
-                    position: Point::new(face.bbox[0] as f32 * sx, (face.bbox[1] as f32 * sy - 14.0).max(0.0)),
+                    position: Point::new(x as f32 * sx, (y as f32 * sy - 14.0).max(0.0)),
                     color: Color::from_rgb(1.0, 0.0, 0.0),
                     size: 16.0,
                     ..Default::default()

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1702,13 +1702,14 @@ impl Application for GooglePiczUI {
                                 .on_press(Message::CancelFaceName)
                         ]
                     } else {
+                        let (x, y, w, h) = face.rect;
                         let label = format!(
                             "Face {} ({},{},{},{}): {}",
                             i + 1,
-                            face.bbox[0],
-                            face.bbox[1],
-                            face.bbox[2],
-                            face.bbox[3],
+                            x,
+                            y,
+                            w,
+                            h,
                             face.name.clone().unwrap_or_else(|| "Unknown".into())
                         );
                         row![


### PR DESCRIPTION
## Summary
- make cascade model discovery robust
- forward face detection errors via sync channels
- draw bounding boxes using sanitized coordinates
- show rect info while editing face names

## Testing
- `cargo check -p sync --features face-recognition` *(fails: could not find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686ab079ed8483338dd98df732d67060