### PR TITLE
Implement Material design style system

### DIFF
--- a/ui/src/album_dialogs.rs
+++ b/ui/src/album_dialogs.rs
@@ -18,7 +18,8 @@ impl std::fmt::Display for AlbumOption {
 pub fn create_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>> {
     if ui.creating_album {
         Some(
-            column![
+            container(
+                column![
                 text_input("Album title", &ui.new_album_title)
                     .style(style::text_input())
                     .on_input(Message::AlbumTitleChanged),
@@ -30,10 +31,12 @@ pub fn create_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, M
                         .style(style::button_secondary())
                         .on_press(Message::CancelCreateAlbum),
                 ]
-                .spacing(10),
+                .spacing(Palette::SPACING),
             ]
-            .spacing(10)
-            .into(),
+            .spacing(Palette::SPACING))
+                .style(style::dialog())
+                .padding(Palette::SPACING)
+                .into(),
         )
     } else {
         None
@@ -43,7 +46,8 @@ pub fn create_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, M
 pub fn rename_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>> {
     if ui.renaming_album.is_some() {
         Some(
-            column![
+            container(
+                column![
                 text_input("New title", &ui.rename_album_title)
                     .style(style::text_input())
                     .on_input(Message::RenameAlbumTitleChanged),
@@ -55,10 +59,12 @@ pub fn rename_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, M
                         .style(style::button_secondary())
                         .on_press(Message::CancelRenameAlbum),
                 ]
-                .spacing(10),
+                .spacing(Palette::SPACING),
             ]
-            .spacing(10)
-            .into(),
+            .spacing(Palette::SPACING))
+                .style(style::dialog())
+                .padding(Palette::SPACING)
+                .into(),
         )
     } else {
         None
@@ -68,7 +74,8 @@ pub fn rename_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, M
 pub fn delete_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>> {
     if ui.deleting_album.is_some() {
         Some(
-            column![
+            container(
+                column![
                 text("Delete album?").size(16),
                 row![
                     button(Icon::new(MaterialSymbol::Delete).color(Palette::ON_PRIMARY))
@@ -78,10 +85,12 @@ pub fn delete_dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, M
                         .style(style::button_secondary())
                         .on_press(Message::CancelDeleteAlbum),
                 ]
-                .spacing(10),
+                .spacing(Palette::SPACING),
             ]
-            .spacing(10)
-            .into(),
+            .spacing(Palette::SPACING))
+                .style(style::dialog())
+                .padding(Palette::SPACING)
+                .into(),
         )
     } else {
         None

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -218,8 +218,7 @@ impl SearchMode {
         SearchMode::MimeType,
         SearchMode::CameraModel,
         SearchMode::CameraMake,
-        ]
-            .push(search::view(self));
+    ];
 }
 
 impl std::fmt::Display for SearchMode {
@@ -1500,11 +1499,11 @@ impl Application for GooglePiczUI {
                 Some(self.search_mode),
                 Message::SearchModeChanged,
             ),
-            button("Search")
+            button(Icon::new(MaterialSymbol::Search).color(Palette::ON_PRIMARY))
                 .style(style::button_primary())
                 .on_press(Message::PerformSearch)
         ];
-        ]
+        header = header
             .push(search::view(self));
 
         if let Some(album_id) = &self.selected_album {

--- a/ui/src/search.rs
+++ b/ui/src/search.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use iced::widget::{button, checkbox, pick_list, row, text_input};
 
-use crate::{style, Message};
+use crate::{style, Icon, MaterialSymbol, Message};
 use crate::style::Palette;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,7 +105,7 @@ pub fn view<'a>(ui: &crate::GooglePiczUI) -> iced::Element<'a, Message> {
         checkbox("Fav", ui.search_favorite, Message::SearchFavoriteToggled)
             .style(style::checkbox_primary()),
         pick_list(&SearchMode::ALL[..], Some(ui.search_mode), Message::SearchModeChanged),
-        button("Search")
+        button(Icon::new(MaterialSymbol::Search).color(Palette::ON_PRIMARY))
             .style(style::button_primary())
             .on_press(Message::PerformSearch)
     ]

--- a/ui/src/settings.rs
+++ b/ui/src/settings.rs
@@ -1,6 +1,6 @@
-use iced::widget::{button, checkbox, column, pick_list, row, text, text_input};
+use iced::widget::{button, checkbox, column, container, pick_list, row, text, text_input};
 
-use crate::{style, Message};
+use crate::{style, Icon, MaterialSymbol, Message};
 use crate::style::Palette;
 
 pub const LOG_LEVELS: [&str; 5] = ["trace", "debug", "info", "warn", "error"];
@@ -8,7 +8,8 @@ pub const LOG_LEVELS: [&str; 5] = ["trace", "debug", "info", "warn", "error"];
 pub fn dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>> {
     if ui.settings_open {
         Some(
-            column![
+            container(
+                column![
                 text("Settings").size(16),
                 pick_list(
                     &LOG_LEVELS[..],
@@ -43,17 +44,19 @@ pub fn dialog<'a>(ui: &crate::GooglePiczUI) -> Option<iced::Element<'a, Message>
                     .style(style::text_input())
                     .on_input(Message::SettingsCachePathChanged),
                 row![
-                    button("Save")
+                    button(Icon::new(MaterialSymbol::Save).color(Palette::ON_PRIMARY))
                         .style(style::button_primary())
                         .on_press(Message::SaveSettings),
-                    button("Cancel")
+                    button(Icon::new(MaterialSymbol::Cancel).color(Palette::ON_SECONDARY))
                         .style(style::button_secondary())
                         .on_press(Message::CloseSettings),
                 ]
-                .spacing(10),
+                .spacing(Palette::SPACING),
             ]
-            .spacing(10)
-            .into(),
+            .spacing(Palette::SPACING))
+                .style(style::dialog())
+                .padding(Palette::SPACING)
+                .into(),
         )
     } else {
         None

--- a/ui/src/style.rs
+++ b/ui/src/style.rs
@@ -28,6 +28,20 @@ impl Palette {
     pub const ICON_SIZE: u16 = 20;
 }
 
+/// Container style used for dialogs and overlays.
+pub fn dialog() -> theme::Container {
+    theme::Container::Custom(Box::new(|_theme: &iced::Theme| container::Appearance {
+        background: Some(Palette::SURFACE.into()),
+        text_color: Some(Palette::ON_SURFACE),
+        border: Border {
+            color: Palette::PRIMARY,
+            width: 1.0,
+            radius: 8.0.into(),
+        },
+        shadow: widget::container::Shadow::default(),
+    }))
+}
+
 /// Style for primary action buttons.
 pub fn button_primary() -> theme::Button {
     theme::Button::Custom(Box::new(|_theme: &iced::Theme| button::Appearance {


### PR DESCRIPTION
## Summary
- design a Material-inspired style module
- add dialog container styling and apply it to album dialogs and settings screen
- use `google_material_symbols` icons for Search, Save and Cancel
- fix UI build issue in `lib.rs`

## Testing
- `cargo check -p ui` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ab07b64c48333885ed9dc62737e7e