### PR TITLE
Extend API client functionality

### DIFF
--- a/api_client/tests/mock_integration.rs
+++ b/api_client/tests/mock_integration.rs
@@ -29,3 +29,27 @@ async fn test_album_management_mock() {
     client.delete_album(&album.id).await.unwrap();
     std::env::remove_var("MOCK_API_CLIENT");
 }
+
+#[tokio::test]
+#[serial]
+async fn test_additional_endpoints_mock() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    let client = ApiClient::new("token".into());
+
+    let ts = client.get_album_modified_time("1").await.unwrap();
+    assert_eq!(ts.as_deref(), Some("2023-01-02T00:00:00Z"));
+
+    let item = client
+        .update_media_item_description("1", "Desc")
+        .await
+        .unwrap();
+    assert_eq!(item.description.as_deref(), Some("Desc"));
+
+    let uploaded = client
+        .upload_media_item(b"img", "img.jpg", "My photo")
+        .await
+        .unwrap();
+    assert_eq!(uploaded.id, "uploaded");
+
+    std::env::remove_var("MOCK_API_CLIENT");
+}


### PR DESCRIPTION
## Summary
- implement album modification date query
- allow updating media item descriptions
- support uploading new media
- cover new endpoints with integration tests

## Testing
- `cargo test -p api_client`
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo clippy -p api_client -- -D warnings` *(fails: 'cargo-clippy' not installed)*


------
https://chatgpt.com/codex/tasks/task_e_686ab07e66288333a696062dd988c632