### PR TITLE
Add e2e tests for face import/export and favorites

### DIFF
--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -47,5 +47,15 @@ name = "face_model_missing_e2e"
 path = "tests/face_model_missing_e2e.rs"
 harness = false
 
+[[test]]
+name = "export_import_faces_e2e"
+path = "tests/export_import_faces_e2e.rs"
+harness = false
+
+[[test]]
+name = "list_favorites_e2e"
+path = "tests/list_favorites_e2e.rs"
+harness = false
+
 [features]
 trace-spans = []

--- a/tests/e2e/tests/export_import_faces_e2e.rs
+++ b/tests/e2e/tests/export_import_faces_e2e.rs
@@ -1,0 +1,45 @@
+use cache::{CacheManager, FaceData};
+use api_client::{MediaItem, MediaMetadata};
+use tempfile::TempDir;
+
+#[tokio::main]
+async fn main() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    std::env::set_var("MOCK_KEYRING", "1");
+
+    let dir = TempDir::new().expect("dir");
+    let db1 = dir.path().join("cache1.sqlite");
+    let cache1 = CacheManager::new(&db1).expect("cache1");
+
+    let item = MediaItem {
+        id: "1".into(),
+        description: None,
+        product_url: String::new(),
+        base_url: String::new(),
+        mime_type: "image/jpeg".into(),
+        media_metadata: MediaMetadata {
+            creation_time: "2024-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+            video: None,
+        },
+        filename: "1.jpg".into(),
+    };
+
+    cache1.insert_media_item(&item).expect("insert item");
+    let faces = vec![FaceData { bbox: [0, 0, 10, 10], name: Some("a".into()) }];
+    let json = serde_json::to_string(&faces).unwrap();
+    cache1.insert_faces(&item.id, &json).unwrap();
+
+    let export_path = dir.path().join("faces.json");
+    cache1.export_faces(&export_path).expect("export");
+
+    let db2 = dir.path().join("cache2.sqlite");
+    let cache2 = CacheManager::new(&db2).expect("cache2");
+    cache2.insert_media_item(&item).expect("insert item2");
+    cache2.import_faces(&export_path).expect("import");
+
+    let stored = cache2.get_faces(&item.id).expect("faces").unwrap();
+    assert_eq!(stored.len(), 1);
+}
+

--- a/tests/e2e/tests/list_favorites_e2e.rs
+++ b/tests/e2e/tests/list_favorites_e2e.rs
@@ -1,0 +1,51 @@
+use cache::CacheManager;
+use api_client::{MediaItem, MediaMetadata};
+use tempfile::TempDir;
+
+#[tokio::main]
+async fn main() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    std::env::set_var("MOCK_KEYRING", "1");
+
+    let dir = TempDir::new().expect("dir");
+    let db = dir.path().join("cache.sqlite");
+    let cache = CacheManager::new(&db).expect("cache");
+
+    let item1 = MediaItem {
+        id: "1".into(),
+        description: None,
+        product_url: String::new(),
+        base_url: String::new(),
+        mime_type: "image/jpeg".into(),
+        media_metadata: MediaMetadata {
+            creation_time: "2024-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+            video: None,
+        },
+        filename: "1.jpg".into(),
+    };
+    let item2 = MediaItem {
+        id: "2".into(),
+        description: None,
+        product_url: String::new(),
+        base_url: String::new(),
+        mime_type: "image/jpeg".into(),
+        media_metadata: MediaMetadata {
+            creation_time: "2024-01-01T00:00:00Z".into(),
+            width: "1".into(),
+            height: "1".into(),
+            video: None,
+        },
+        filename: "2.jpg".into(),
+    };
+
+    cache.insert_media_item(&item1).expect("insert1");
+    cache.insert_media_item(&item2).expect("insert2");
+    cache.set_favorite(&item2.id, true).expect("fav");
+
+    let favs = cache.get_favorite_media_items().expect("favs");
+    assert_eq!(favs.len(), 1);
+    assert_eq!(favs[0].id, item2.id);
+}
+


### PR DESCRIPTION
## Summary
- add missing e2e tests for exporting/importing faces
- add e2e test for listing favorite media items

## Testing
- `cargo test -p e2e --no-run` *(fails: failed to run custom build command for `opencv`)*

------
https://chatgpt.com/codex/tasks/task_e_686ab07f32808333adb4e12e4b7b3059