### PR TITLE
Fix packaging paths and update user docs

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -39,3 +39,25 @@ cargo run --package googlepicz --features googlepicz/tokio-console,sync/trace-sp
 ```
 
 Die Konsole zeigt laufende Tasks an, detaillierte Span-Daten finden sich in `~/.googlepicz/googlepicz.log`.
+
+## Manuell zu installierende Packaging-Werkzeuge
+
+Der Packager von GooglePicz nutzt einige externe Tools, die nicht automatisch mit
+`cargo` installiert werden können. Stelle sicher, dass sie über die jeweilige
+Paketverwaltung verfügbar sind und im `PATH` liegen:
+
+- **macOS**: `codesign`, `hdiutil` und `xcrun` sind Teil der Xcode Command Line
+  Tools. Installiere sie mit:
+
+  ```bash
+  xcode-select --install
+  ```
+
+- **Windows**: Der Installer wird mit **NSIS** erstellt. Lade das Paket von
+  <https://nsis.sourceforge.io/> herunter und füge `makensis` zum `PATH`
+  hinzu. Für Codesigning wird `signtool` aus dem Windows SDK benötigt.
+
+- **Linux**: Optionales Signieren von `.deb`-Paketen setzt `dpkg-sig` voraus.
+
+Ohne diese Programme werden die entsprechenden Arbeitsschritte übersprungen bzw.
+schlagen fehl.


### PR DESCRIPTION
## Summary
- ensure artifact moves show source/dest paths
- resolve paths from workspace root when packaging
- document manual installation of packaging tools

## Testing
- `cargo test -p packaging --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686ab0812cfc8333a9a72e139a0d06f8