### PR TITLE
Add clippy and idiom warnings

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 //! API client module for Google Photos.
 
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};

--- a/app/src/bin/sync_cli.rs
+++ b/app/src/bin/sync_cli.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 use cache::CacheManager;
 use clap::{Parser, Subcommand};
 use api_client::ApiClient;

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 //! Main application entry point for GooglePicz.
 
 use auth::{authenticate, ensure_access_token_valid};

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 //! Authentication module for Google Photos API.
 
 use keyring::Entry;

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 //! Cache module for Google Photos data.
 
 use chrono::{DateTime, Utc, TimeZone};

--- a/face_recognition/src/lib.rs
+++ b/face_recognition/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 //! Face recognition module for GooglePicz.
 //!
 //! The current implementation only provides placeholder functions.

--- a/packaging/src/bin/ci_checks.rs
+++ b/packaging/src/bin/ci_checks.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     packaging::utils::verify_metadata_package_name("googlepicz")?;
     packaging::utils::verify_artifact_names()?;

--- a/packaging/src/lib.rs
+++ b/packaging/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 //! Packaging module for GooglePicz.
 //!
 //! The packager can sign and notarize macOS builds when the following

--- a/packaging/src/main.rs
+++ b/packaging/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 use clap::Parser;
 
 #[derive(Parser)]

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 //! Synchronization module for Google Photos data.
 
 use api_client::ApiClient;

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -1,1 +1,3 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 // E2E tests crate

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
 //! User Interface module for GooglePicz.
 
 mod image_loader;


### PR DESCRIPTION
## Summary
- warn on all clippy lints in each crate
- warn about 2018 idioms in each crate

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo clippy --all -- -D warnings` *(fails: 'cargo-clippy' is not installed)*
- `cargo test --quiet` *(fails: could not find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686ab083e9f8833394fe0aaf72e1ac89