### PR TITLE
Add e2e tests for album rename and upload

### DIFF
--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -57,5 +57,15 @@ name = "list_favorites_e2e"
 path = "tests/list_favorites_e2e.rs"
 harness = false
 
+[[test]]
+name = "rename_album_e2e"
+path = "tests/rename_album_e2e.rs"
+harness = false
+
+[[test]]
+name = "upload_item_e2e"
+path = "tests/upload_item_e2e.rs"
+harness = false
+
 [features]
 trace-spans = []

--- a/tests/e2e/tests/rename_album_e2e.rs
+++ b/tests/e2e/tests/rename_album_e2e.rs
@@ -1,0 +1,36 @@
+use assert_cmd::prelude::*;
+use api_client::ApiClient;
+use cache::CacheManager;
+use tempfile::TempDir;
+use std::process::Command;
+
+#[tokio::main]
+async fn main() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "test");
+
+    let dir = TempDir::new().expect("dir");
+    let home = dir.path();
+    let base = home.join(".googlepicz");
+    std::fs::create_dir_all(&base).expect("create base");
+    let db = base.join("cache.sqlite");
+    let cache = CacheManager::new(&db).expect("cache");
+
+    let client = ApiClient::new("token".into());
+    let album = client.create_album("Holiday").await.expect("album");
+    cache.insert_album(&album).expect("insert album");
+
+    let mut cmd = Command::cargo_bin("sync_cli").expect("bin");
+    cmd.env("MOCK_API_CLIENT", "1")
+        .env("MOCK_KEYRING", "1")
+        .env("MOCK_REFRESH_TOKEN", "test")
+        .env("HOME", home)
+        .args(&["rename-album", &album.id, "Renamed"])
+        .assert()
+        .success();
+
+    let cache = CacheManager::new(&db).expect("cache2");
+    let albums = cache.get_all_albums().expect("albums");
+    assert_eq!(albums[0].title.as_deref(), Some("Renamed"));
+}

--- a/tests/e2e/tests/upload_item_e2e.rs
+++ b/tests/e2e/tests/upload_item_e2e.rs
@@ -1,0 +1,33 @@
+use assert_cmd::prelude::*;
+use cache::CacheManager;
+use tempfile::TempDir;
+use std::process::Command;
+
+#[tokio::main]
+async fn main() {
+    std::env::set_var("MOCK_API_CLIENT", "1");
+    std::env::set_var("MOCK_KEYRING", "1");
+    std::env::set_var("MOCK_REFRESH_TOKEN", "test");
+
+    let dir = TempDir::new().expect("dir");
+    let home = dir.path();
+    let base = home.join(".googlepicz");
+    std::fs::create_dir_all(&base).expect("create base");
+    let db = base.join("cache.sqlite");
+
+    let img_path = dir.path().join("dummy.jpg");
+    std::fs::write(&img_path, [0u8; 10]).expect("write img");
+
+    let mut cmd = Command::cargo_bin("sync_cli").expect("bin");
+    cmd.env("MOCK_API_CLIENT", "1")
+        .env("MOCK_KEYRING", "1")
+        .env("MOCK_REFRESH_TOKEN", "test")
+        .env("HOME", home)
+        .args(&["upload-item", img_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let cache = CacheManager::new(&db).expect("cache");
+    let items = cache.get_all_media_items().expect("items");
+    assert_eq!(items.len(), 1);
+}


### PR DESCRIPTION
## Summary
- add new e2e tests `rename_album_e2e` and `upload_item_e2e`
- register tests in `tests/e2e/Cargo.toml`

## Testing
- `cargo test --manifest-path tests/e2e/Cargo.toml --no-run` *(fails: glib-2.0 pkg-config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686af771a4808333849a00169bb3b949