### PR TITLE
Improve sync backoff and status handling

### DIFF
--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -357,9 +357,10 @@ impl CacheManager {
                 .map_err(|e| CacheError::DatabaseError(format!("Failed to insert metadata: {}", e)))?;
         }
 
+        drop(item_stmt);
+        drop(meta_stmt);
         tx.commit()
-            .map_err(|e| CacheError::DatabaseError(format!("Failed to commit transaction: {}", e)))?
-        ;
+            .map_err(|e| CacheError::DatabaseError(format!("Failed to commit transaction: {}", e)))?;
         Ok(())
     }
 

--- a/sync/tests/token_refresh_abort.rs
+++ b/sync/tests/token_refresh_abort.rs
@@ -1,0 +1,27 @@
+use sync::{Syncer, SyncTaskError};
+use serial_test::serial;
+use tokio::sync::mpsc;
+use tokio::time::{advance, pause, Duration, timeout};
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn token_refresh_aborts_after_failures() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    let (err_tx, mut err_rx) = mpsc::unbounded_channel();
+    pause();
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (handle, shutdown) = Syncer::start_token_refresh_task(Duration::from_secs(1), err_tx, None, None);
+            advance(Duration::from_secs(6)).await; // enough for >5 failures
+            let _ = shutdown.send(());
+            let _ = handle.await;
+        })
+        .await;
+    let mut seen_abort = false;
+    while let Ok(Some(err)) = timeout(Duration::from_secs(1), err_rx.recv()).await {
+        if matches!(err, SyncTaskError::Aborted(_)) { seen_abort = true; break; }
+    }
+    assert!(seen_abort, "no Aborted error emitted");
+    std::env::remove_var("MOCK_KEYRING");
+}

--- a/sync/tests/token_refresh_restart.rs
+++ b/sync/tests/token_refresh_restart.rs
@@ -1,0 +1,27 @@
+use sync::{Syncer, SyncTaskError};
+use serial_test::serial;
+use tokio::sync::mpsc;
+use tokio::time::{advance, pause, Duration, timeout};
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn token_refresh_restart_attempts_reported() {
+    std::env::set_var("MOCK_KEYRING", "1");
+    let (err_tx, mut err_rx) = mpsc::unbounded_channel();
+    pause();
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (handle, shutdown) = Syncer::start_token_refresh_task(Duration::from_secs(1), err_tx, None, None);
+            advance(Duration::from_secs(2)).await; // allow a couple failures
+            let _ = shutdown.send(());
+            let _ = handle.await;
+        })
+        .await;
+    let mut attempts = 0u32;
+    while let Ok(Some(err)) = timeout(Duration::from_secs(1), err_rx.recv()).await {
+        if let SyncTaskError::RestartAttempt(n) = err { attempts = n; }
+    }
+    assert!(attempts >= 1, "no restart attempt emitted");
+    std::env::remove_var("MOCK_KEYRING");
+}

--- a/sync/tests/token_refresh_task.rs
+++ b/sync/tests/token_refresh_task.rs
@@ -3,7 +3,9 @@ use serial_test::serial;
 use tokio::sync::mpsc;
 use tokio::time::{timeout, Duration};
 use tempfile::tempdir;
+#[cfg(feature = "ui")]
 use ui::{GooglePiczUI, Message};
+#[cfg(feature = "ui")]
 use iced::Application;
 
 #[tokio::test(flavor = "current_thread")]
@@ -16,7 +18,7 @@ async fn test_token_refresh_task_reports_error() {
     local
         .run_until(async {
             let (handle, shutdown) =
-                Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx, None);
+                Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx, None, None);
             let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap();
             assert!(err.is_some());
             let _ = shutdown.send(());
@@ -26,6 +28,7 @@ async fn test_token_refresh_task_reports_error() {
     std::env::remove_var("MOCK_KEYRING");
 }
 
+#[cfg(feature = "ui")]
 #[test]
 #[serial]
 fn test_token_refresh_error_forwarded_to_ui() {
@@ -40,7 +43,7 @@ fn test_token_refresh_error_forwarded_to_ui() {
         local
             .run_until(async move {
                 let (handle, shutdown) =
-                    Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx, None);
+                    Syncer::start_token_refresh_task(Duration::from_millis(10), err_tx, None, None);
                 let err = timeout(Duration::from_secs(5), err_rx.recv()).await.unwrap().unwrap();
                 let _ = shutdown.send(());
                 let _ = handle.await;


### PR DESCRIPTION
## Summary
- fix transaction commit in cache
- forward sync status to UI and CLI
- add restart/abort handling to token refresh task
- add token refresh regression tests

## Testing
- `cargo check -p sync --no-default-features`
- `cargo test -p sync --no-default-features --test abort_restart --test error_reporting --test repeated_failures --test status_reporting --test sync_flow --test sync_media_items_error --test token_refresh_task --test token_refresh_abort --test token_refresh_restart` *(fails: test failed, to rerun pass `-p sync --test abort_restart`)*

------
https://chatgpt.com/codex/tasks/task_e_686bab2cf7248333a4eb3cee8c07e172