### PR TITLE
Add faces filter to search

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -151,6 +151,7 @@ pub enum Message {
     SearchStartChanged(String),
     SearchEndChanged(String),
     SearchFavoriteToggled(bool),
+    SearchFacesToggled(bool),
     PerformSearch,
     #[cfg(feature = "gstreamer")]
     PlayVideo(MediaItem),
@@ -208,10 +209,11 @@ pub enum SearchMode {
     MimeType,
     CameraModel,
     CameraMake,
+    Faces,
 }
 
 impl SearchMode {
-    const ALL: [SearchMode; 8] = [
+    const ALL: [SearchMode; 9] = [
         SearchMode::Filename,
         SearchMode::Description,
         SearchMode::Text,
@@ -220,6 +222,7 @@ impl SearchMode {
         SearchMode::MimeType,
         SearchMode::CameraModel,
         SearchMode::CameraMake,
+        SearchMode::Faces,
     ];
 }
 
@@ -234,6 +237,7 @@ impl std::fmt::Display for SearchMode {
             SearchMode::MimeType => "Dateityp",
             SearchMode::CameraModel => "Kamera-Modell",
             SearchMode::CameraMake => "Kamera-Hersteller",
+            SearchMode::Faces => "Gesichter",
         };
         write!(f, "{}", s)
     }
@@ -289,6 +293,7 @@ pub struct GooglePiczUI {
     search_start: String,
     search_end: String,
     search_favorite: bool,
+    search_faces: bool,
     error_log_path: PathBuf,
     settings_open: bool,
     config_path: PathBuf,
@@ -556,6 +561,7 @@ impl Application for GooglePiczUI {
             search_start: String::new(),
             search_end: String::new(),
             search_favorite: false,
+            search_faces: false,
             error_log_path,
             settings_open: open_settings,
             config_path,
@@ -1225,6 +1231,9 @@ impl Application for GooglePiczUI {
             Message::SearchFavoriteToggled(v) => {
                 self.search_favorite = v;
             }
+            Message::SearchFacesToggled(v) => {
+                self.search_faces = v;
+            }
             Message::PerformSearch => {
                 if let Some(cm) = &self.cache_manager {
                     let cm = cm.clone();
@@ -1236,6 +1245,7 @@ impl Application for GooglePiczUI {
                     let fav = self.search_favorite;
                     let make_sel = self.search_camera_make.clone();
                     let mime_sel = self.search_mime.clone();
+                    let faces = self.search_faces;
                     return Command::perform(
                         async move {
                             let cache = {
@@ -1261,8 +1271,6 @@ impl Application for GooglePiczUI {
                                 _ => None,
                             };
 
-                            let start_dt = parse_single_date(&start, false);
-                            let end_dt = parse_single_date(&end, true);
                             let camera_model_param = if mode == SearchMode::CameraModel {
                                 Some(query.clone())
                             } else if camera.is_empty() {
@@ -1285,6 +1293,7 @@ impl Application for GooglePiczUI {
                             } else {
                                 None
                             };
+                            let faces_only = faces;
                                 SearchMode::DateRange => {
                                     if let Some((s, e)) = search::parse_date_query(&query) {
                                         cache
@@ -1319,7 +1328,7 @@ impl Application for GooglePiczUI {
 
                             let start_dt = search::parse_single_date(&start, false);
                             let end_dt = search::parse_single_date(&end, true);
-                            cache
+                            let mut extra = cache
                                 .query_media_items_async(
                                     camera_model_param,
                                     camera_make_param,
@@ -1330,13 +1339,24 @@ impl Application for GooglePiczUI {
                                     if mode == SearchMode::Text { Some(query.clone()) } else { None },
                                 )
                                 .await
-                                .map_err(|e| e.to_string())
-                                .map(|mut extra| {
-                                    if let Some(base) = &base {
-                                        extra.retain(|i| base.iter().any(|b| b.id == i.id));
+                                .map_err(|e| e.to_string())?;
+
+                            if faces_only {
+                                let mut filtered = Vec::new();
+                                for item in extra.into_iter() {
+                                    if let Ok(list) = cache.get_faces_for_media_item(&item.id).await {
+                                        if !list.is_empty() {
+                                            filtered.push(item);
+                                        }
                                     }
-                                    extra
-                                })
+                                }
+                                extra = filtered;
+                            }
+
+                            if let Some(base) = &base {
+                                extra.retain(|i| base.iter().any(|b| b.id == i.id));
+                            }
+                            Ok::<_, String>(extra)
                         },
                         Message::PhotosLoaded,
                     );

--- a/ui/src/search.rs
+++ b/ui/src/search.rs
@@ -14,10 +14,11 @@ pub enum SearchMode {
     MimeType,
     CameraModel,
     CameraMake,
+    Faces,
 }
 
 impl SearchMode {
-    pub const ALL: [SearchMode; 8] = [
+    pub const ALL: [SearchMode; 9] = [
         SearchMode::Filename,
         SearchMode::Description,
         SearchMode::Text,
@@ -26,6 +27,7 @@ impl SearchMode {
         SearchMode::MimeType,
         SearchMode::CameraModel,
         SearchMode::CameraMake,
+        SearchMode::Faces,
     ];
 
     pub fn placeholder(self) -> &'static str {
@@ -37,6 +39,7 @@ impl SearchMode {
             SearchMode::MimeType => "Mime type",
             SearchMode::CameraModel => "Camera model",
             SearchMode::CameraMake => "Camera make",
+            SearchMode::Faces => "Has faces",
             SearchMode::DateRange => "YYYY-MM-DD..YYYY-MM-DD",
         }
     }
@@ -53,6 +56,7 @@ impl std::fmt::Display for SearchMode {
             SearchMode::MimeType => "Dateityp",
             SearchMode::CameraModel => "Kamera-Modell",
             SearchMode::CameraMake => "Kamera-Hersteller",
+            SearchMode::Faces => "Gesichter",
         };
         write!(f, "{}", s)
     }
@@ -103,6 +107,8 @@ pub fn view<'a>(ui: &crate::GooglePiczUI) -> iced::Element<'a, Message> {
             .style(style::text_input())
             .on_input(Message::SearchEndChanged),
         checkbox("Fav", ui.search_favorite, Message::SearchFavoriteToggled)
+            .style(style::checkbox_primary()),
+        checkbox("Faces", ui.search_faces, Message::SearchFacesToggled)
             .style(style::checkbox_primary()),
         pick_list(&SearchMode::ALL[..], Some(ui.search_mode), Message::SearchModeChanged),
         button(Icon::new(MaterialSymbol::Search).color(Palette::ON_PRIMARY))


### PR DESCRIPTION
## Summary
- extend search modes with new "Faces" option
- add checkbox to require faces
- store new filter state in `GooglePiczUI`
- filter results via cache when searching

## Testing
- `cargo test --no-run --workspace --all-targets --no-default-features --features no-gstreamer` *(fails: could not compile `cache` due to missing system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_686c2cedfc748333a92d34a3e6050b31