### PR TITLE
Refactor UI cache initialization

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -39,7 +39,7 @@ use iced::widget::{
 use iced::Border;
 use iced::Color;
 use iced::{event, keyboard, executor, Application, Command, Element, Length, Settings, Subscription, Theme};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::io::Write;
 use std::sync::Arc;
 use sync::{SyncProgress, SyncTaskError};
@@ -429,6 +429,28 @@ impl GooglePiczUI {
             |_| Message::ClearErrors,
         )
     }
+
+    fn init_cache_manager(
+        cache_path: &Path,
+        error_log_path: &Path,
+        errors: &mut Vec<String>,
+    ) -> Option<Arc<Mutex<CacheManager>>> {
+        match CacheManager::new(cache_path) {
+            Ok(cm) => Some(Arc::new(Mutex::new(cm))),
+            Err(e) => {
+                let msg = format!("Failed to initialize cache: {}", e);
+                errors.push(msg.clone());
+                if let Ok(mut f) = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(error_log_path)
+                {
+                    let _ = writeln!(f, "{}", msg);
+                }
+                None
+            }
+        }
+    }
 }
 
 impl Application for GooglePiczUI {
@@ -465,21 +487,7 @@ impl Application for GooglePiczUI {
             init_errors.push(format!("GStreamer initialization failed: {}", e));
         }
 
-        let cache_manager = match CacheManager::new(&cache_path) {
-            Ok(cm) => Some(Arc::new(Mutex::new(cm))),
-            Err(e) => {
-                let msg = format!("Failed to initialize cache: {}", e);
-                init_errors.push(msg.clone());
-                if let Ok(mut f) = std::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&error_log_path)
-                {
-                    let _ = writeln!(f, "{}", msg);
-                }
-                None
-            }
-        };
+        let cache_manager = Self::init_cache_manager(&cache_path, &error_log_path, &mut init_errors);
 
         let last_synced = if let Some(cm) = &cache_manager {
             let cache = cm.blocking_lock();


### PR DESCRIPTION
## Summary
- pull cache init logic out of `GooglePiczUI::new` into a helper
- reuse helper to shorten `new`

## Testing
- `cargo test --workspace` *(fails: could not run custom build command for `clang-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_686c353cd0c88333b120898453ad29a7