### PR TITLE
Define face-recognition feature in cache

### DIFF
--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -21,6 +21,7 @@ criterion = "0.5"
 
 [features]
 trace-spans = []
+face-recognition = []
 
 [[bench]]
 name = "cache_bench"

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -215,7 +215,7 @@ fn apply_migrations(conn: &mut Connection) -> Result<(), CacheError> {
 }
 
 impl CacheManager {
-    pub fn lock_conn(&self) -> Result<std::sync::MutexGuard<Connection>, CacheError> {
+    pub fn lock_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>, CacheError> {
         self.conn
             .lock()
             .map_err(|_| CacheError::Other("Poisoned lock".into()))
@@ -532,7 +532,7 @@ impl CacheManager {
         mime_type: Option<&str>,
         text: Option<&str>,
     ) -> Result<Vec<api_client::MediaItem>, CacheError> {
-        let start = std::time::Instant::now();
+        let timer = std::time::Instant::now();
         let conn = self.lock_conn()?;
         let sql = concat!(
             "SELECT m.id, m.description, m.product_url, m.base_url, m.mime_type, md.creation_time, md.width, md.height, md.camera_make, md.camera_model, md.fps, md.status, m.filename ",
@@ -597,7 +597,7 @@ impl CacheManager {
                 CacheError::DatabaseError(format!("Failed to retrieve media item from iterator: {}", e))
             })?);
         }
-        tracing::info!("query_time_ms" = %start.elapsed().as_millis(), "query" = "general", "count" = items.len());
+        tracing::info!("query_time_ms" = %timer.elapsed().as_millis(), "query" = "general", "count" = items.len());
         Ok(items)
     }
 

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -4,7 +4,7 @@
 
 mod image_loader;
 mod video_downloader;
-#[path = "../app/src/config.rs"]
+#[path = "../../app/src/config.rs"]
 mod app_config;
 mod style;
 mod icon;
@@ -1285,37 +1285,6 @@ impl Application for GooglePiczUI {
                             } else {
                                 None
                             };
-                                SearchMode::DateRange => {
-                                    if let Some((s, e)) = search::parse_date_query(&query) {
-                                        cache
-                                            .get_media_items_by_date_range(s, e)
-                                            .map_err(|e| e.to_string())
-                                    } else {
-                                        Ok(Vec::new())
-                                    }
-                                }
-                                SearchMode::Description => cache
-                                    .get_media_items_by_description(&query)
-                                    .map_err(|e| e.to_string()),
-                                SearchMode::Favoriten => cache
-                                    .get_favorite_media_items()
-                                    .map_err(|e| e.to_string()),
-                                SearchMode::Filename => cache
-                                    .get_media_items_by_filename(&query)
-                                    .map_err(|e| e.to_string()),
-                                SearchMode::MimeType => cache
-                                    .get_media_items_by_mime_type(&query)
-                                    .map_err(|e| e.to_string()),
-                                SearchMode::CameraModel => cache
-                                    .get_media_items_by_camera_model(&query)
-                                    .map_err(|e| e.to_string()),
-                                SearchMode::CameraMake => cache
-                                    .get_media_items_by_camera_make(&query)
-                                    .map_err(|e| e.to_string()),
-                                SearchMode::Text => cache
-                                    .get_media_items_by_text(&query)
-                                    .map_err(|e| e.to_string()),
-                            }?;
 
                             let start_dt = search::parse_single_date(&start, false);
                             let end_dt = search::parse_single_date(&end, true);


### PR DESCRIPTION
## Summary
- add `face-recognition` feature to `cache` crate
- add lifetime to `lock_conn`
- fix broken path in `ui` crate
- clean up invalid search code

## Testing
- `cargo check -p cache`


------
https://chatgpt.com/codex/tasks/task_e_686c353fca0083338a9bf53bf8315189