### PR TITLE
Remove beta status notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,9 @@
   [![Rust](https://img.shields.io/badge/Rust-1.70+-orange?logo=rust)](https://www.rust-lang.org/)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   [![CI](https://github.com/Christopher-Schulze/GooglePicz/actions/workflows/ci.yml/badge.svg)](https://github.com/Christopher-Schulze/GooglePicz/actions/workflows/ci.yml)
-  [![Project Status: Beta](https://img.shields.io/badge/status-Beta-blue)](https://github.com/Christopher-Schulze/GooglePicz)
 </div>
 
-
 > A native Google Photos client for macOS and Windows, built with Rust for maximum performance and efficiency.
-
-## 🚀 Project Status: Beta
-
-**Note**: GooglePicz is still experimental but now includes advanced search filters, optional video playback and an early face recognition module. The APIs may change as these features are refined.
 
 ## 🎯 Project Goals
 
@@ -299,7 +293,6 @@ cargo run --package packaging --bin packager -- --format appimage
 ## Running Tests
 
 Unit tests mock external services using environment variables. Run `cargo test` and everything should pass without Google credentials.
-
 
 ## 📄 License
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -16,7 +16,6 @@
   - Fixed invalid `use` statements in `main.rs`, `api_client/src/lib.rs`, `sync/src/lib.rs`, and `ui/src/lib.rs` to reflect the corrected crate names.
   - Aligned `KEYRING_SERVICE_NAME` in `auth/src/lib.rs` with the project name for consistency.
   - Refactored `ui/src/image_loader.rs` to remove the in-memory cache and mutable state from `load_thumbnail`, resolving potential concurrency issues.
-  - Created `docs/TODO123.md` to outline next steps and potential improvements.
 ## 2024-07-29
 - Initial project setup: Created Rust workspace and module folders (`auth`, `api_client`, `ui`, `cache`, `sync`, `packaging`).
 - Configured main `Cargo.toml` for workspace and added global dependencies and release profiles.

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -3,9 +3,7 @@
 ## 📋 Overview
 GooglePicz is a native Google Photos client being developed in Rust. The application focuses on performance, security, and user experience. The project is structured as a Rust workspace with multiple crates.
 
-## 🚀 Project Status: Beta
 
-**Note**: GooglePicz is still experimental but now includes advanced search filters, optional video playback and an early face recognition module. The APIs may change as these features are refined.
 
 ## 🏗️ Architecture
 
@@ -334,6 +332,4 @@ The script builds the `googlepicz` binary, launches it under `xvfb-run` and
 saves images of the main window and the settings dialog into
 `docs/screenshots`.
 
-## ⚠️ Note
-This project is under active development. Features and APIs are subject to change. Documentation will be updated as the project evolves.
 The `Changelog.md` file tracks changes over time.


### PR DESCRIPTION
## Summary
- scrub Beta wording from project docs
- drop reference to missing TODO123 page

## Testing
- `cargo test --workspace --all-targets` *(fails: couldn't find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686cc4e13e5883339147b96e4af3bfe3