### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [workspace.dependencies]

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -66,3 +66,6 @@
 - Added startup profiling using `tokio-console` and `tracing`.
 - Logged initialization time and memory usage in `app/src/main.rs`.
 - Summarized the collected metrics in `docs/PERFORMANCE_TUNING.md`.
+
+## 2025-07-09
+- Release 0.1.1.


### PR DESCRIPTION
## Summary
- update workspace version to 0.1.1
- note the 0.1.1 release in the changelog

## Testing
- `cargo test --all` *(fails: clang-sys could not find libclang)*
- `cargo bench -p cache`
- `MOCK_COMMANDS=1 cargo run -p packaging --bin packager`


------
https://chatgpt.com/codex/tasks/task_e_686cd1dbf53c8333816372babbed9cac